### PR TITLE
feat: add global auth middleware

### DIFF
--- a/middleware/auth.global.ts
+++ b/middleware/auth.global.ts
@@ -1,0 +1,20 @@
+export default defineNuxtRouteMiddleware(async (to) => {
+    // Public rotalar (gerekirse genişlet)
+    const PUBLIC = new Set(['/', '/blog', '/login', '/register']);
+
+    // login sayfasında kullanıcı zaten girişliyse dashboard'a at
+    if (to.path === '/login') {
+        const { user, fetchMe } = useAuth();
+        if (!user.value) await fetchMe();
+        if (user.value) return navigateTo('/dashboard');
+        return; // login public, kalan işlem yok
+    }
+
+    // public ise dokunma
+    if (PUBLIC.has(to.path)) return;
+
+    // gerisi korumalı
+    const { user, fetchMe } = useAuth();
+    if (!user.value) await fetchMe();
+    if (!user.value) return navigateTo('/login');
+});

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -1,8 +1,0 @@
-// middleware/auth.ts
-export default defineNuxtRouteMiddleware((to, from) => {
-  const { isLoggedIn } = useAuth()
-
-  if (!isLoggedIn.value) {
-    return navigateTo('/login')
-  }
-})


### PR DESCRIPTION
## Summary
- add global auth middleware that redirects based on login state
- remove old per-route auth middleware

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint middleware/auth.global.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aebbfed7cc83248bb9d5cd4c2d03e3