### PR TITLE
feat: add mobile drawer for dashboard panels

### DIFF
--- a/pages/components/dashboard/DashboardDrawer.vue
+++ b/pages/components/dashboard/DashboardDrawer.vue
@@ -1,0 +1,44 @@
+<template>
+  <transition name="slide">
+    <div v-if="true" class="fixed inset-0 bg-white z-50 md:hidden overflow-y-auto">
+      <div class="p-4">
+        <button class="mb-4 text-gray-500" @click="$emit('close')">
+          Kapat
+        </button>
+        <NotificationsPanel
+          v-if="type === 'notifications'"
+          :notifications="notifications"
+        />
+        <TaskCreatePanel v-else-if="type === 'taskCreate'" />
+      </div>
+    </div>
+  </transition>
+</template>
+
+<script setup lang="ts">
+import NotificationsPanel from './notifications.vue'
+import TaskCreatePanel from './taskCreate.vue'
+
+const props = defineProps<{
+  type: 'notifications' | 'taskCreate'
+  notifications?: any[]
+}>()
+
+defineEmits(['close'])
+</script>
+
+<style scoped>
+.slide-enter-from,
+.slide-leave-to {
+  transform: translateX(100%);
+}
+.slide-enter-active,
+.slide-leave-active {
+  transition: transform 0.3s ease;
+}
+.slide-enter-to,
+.slide-leave-from {
+  transform: translateX(0);
+}
+</style>
+

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -1,9 +1,31 @@
 <template>
   <div class="bg-gray-50 min-h-screen">
     <Navbar />
-    <!-- 1:3:2 oranında grid -->
+
+    <!-- Mobil görünüm -->
+    <div class="md:hidden p-4">
+      <div class="flex items-center justify-between mb-4">
+        <button class="p-2 rounded-md bg-white shadow" @click="menuOpen = !menuOpen">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
+      <div v-if="menuOpen" class="mb-4 flex flex-col gap-2">
+        <button @click="openDrawer('notifications')" class="px-4 py-2 rounded bg-blue-500 text-white">
+          Bildirimler
+        </button>
+        <button @click="openDrawer('taskCreate')" class="px-4 py-2 rounded bg-green-500 text-white">
+          Görev Oluştur
+        </button>
+      </div>
+
+      <TaskListPanel />
+    </div>
+
+    <!-- Masaüstü görünüm: 1:3:2 oranında grid -->
     <div
-        class="grid px-8 gap-6 py-6"
+        class="hidden md:grid px-8 gap-6 py-6"
         style="height: calc(100vh - 4rem); grid-template-columns: 1fr 3fr 2fr;"
     >
       <!-- Bildirimler + Yorumlar -->
@@ -25,8 +47,14 @@
 
       <!-- Görev Oluştur -->
       <TaskCreatePanel class="flex flex-col h-full"/>
-
     </div>
+
+    <DashboardDrawer
+        v-if="drawerType"
+        :type="drawerType"
+        :notifications="notifications"
+        @close="drawerType = null"
+    />
   </div>
 </template>
 
@@ -37,10 +65,17 @@ import TaskListPanel from './components/dashboard/taskList.vue'
 import TaskCreatePanel from './components/dashboard/taskCreate.vue'
 import CommentListPanel from './components/dashboard/commentList.vue'
 import Navbar from './components/bar/Navbar.vue'
+import DashboardDrawer from './components/dashboard/DashboardDrawer.vue'
 import { useFetch } from '#app'
 
 const comments = ref([])
 const notifications = ref([])
+const drawerType = ref<null | 'notifications' | 'taskCreate'>(null)
+const menuOpen = ref(false)
+
+const openDrawer = (type: 'notifications' | 'taskCreate') => {
+  drawerType.value = type
+}
 
 onMounted(async () => {
   try {


### PR DESCRIPTION
## Summary
- add `DashboardDrawer` for mobile notifications/task creation
- wire up `dashboard.vue` with hamburger menu and drawer state

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c186b4992c83249fcf91fa7b55761a