### PR TITLE
feat(dashboard): add sprint management mobile menu

### DIFF
--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -18,6 +18,33 @@
         <button @click="openDrawer('taskCreate')" class="px-4 py-2 rounded bg-green-500 text-white">
           Görev Oluştur
         </button>
+        <div v-if="canSeeSprintMenu" class="flex flex-col">
+          <button
+              class="px-4 py-2 rounded bg-blue-500 text-white flex items-center justify-between"
+              @click="sprintMenuOpen = !sprintMenuOpen"
+          >
+            Sprint Yönetimi
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7" /></svg>
+          </button>
+          <div v-if="sprintMenuOpen" class="mt-2 flex flex-col gap-2 ml-4">
+            <NuxtLink
+                v-if="hasAnyRole(['admin', 'director'])"
+                to="/sprint/create"
+                class="px-4 py-2 rounded bg-blue-100 text-blue-700"
+            >
+              Sprint Oluştur
+            </NuxtLink>
+            <NuxtLink
+                v-if="hasAnyRole(['admin', 'director'])"
+                to="/sprint/task-list"
+                class="px-4 py-2 rounded bg-blue-100 text-blue-700"
+            >
+              Sprint Görev Listesi
+            </NuxtLink>
+            <NuxtLink to="/sprint/meta" class="px-4 py-2 rounded bg-blue-100 text-blue-700">Sprint Meta Bilgileri</NuxtLink>
+            <NuxtLink to="/sprint/chart" class="px-4 py-2 rounded bg-blue-100 text-blue-700">Sprint Charts</NuxtLink>
+          </div>
+        </div>
       </div>
 
       <TaskListPanel />
@@ -59,7 +86,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, computed } from 'vue'
 import NotificationsPanel from './components/dashboard/notifications.vue'
 import TaskListPanel from './components/dashboard/taskList.vue'
 import TaskCreatePanel from './components/dashboard/taskCreate.vue'
@@ -67,11 +94,17 @@ import CommentListPanel from './components/dashboard/commentList.vue'
 import Navbar from './components/bar/Navbar.vue'
 import DashboardDrawer from './components/dashboard/DashboardDrawer.vue'
 import { useFetch } from '#app'
+import { useAuthStore } from '@/stores/authStore'
 
 const comments = ref([])
 const notifications = ref([])
 const drawerType = ref<null | 'notifications' | 'taskCreate'>(null)
 const menuOpen = ref(false)
+const sprintMenuOpen = ref(false)
+
+const auth = useAuthStore()
+const hasAnyRole = auth.hasAnyRole
+const canSeeSprintMenu = computed(() => hasAnyRole(['admin', 'lead', 'director', 'developer']))
 
 const openDrawer = (type: 'notifications' | 'taskCreate') => {
   drawerType.value = type


### PR DESCRIPTION
## Summary
- show Sprint Yönetimi dropdown in dashboard mobile menu
- compute sprint menu visibility using user roles

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c3dccd310083248b3008ee9e940be3