### PR TITLE
Fix document writer link

### DIFF
--- a/pages/documents/TreeItem.vue
+++ b/pages/documents/TreeItem.vue
@@ -3,7 +3,7 @@
     <div class="flex items-center justify-between group">
       <!-- Başlık kısmı yönlendirme için router-link oldu -->
       <NuxtLink
-          :to="`writer/${document.id}`"
+          :to="`/documents/writer/${document.id}`"
           class="text-gray-800 font-medium hover:underline"
       >
         {{ document.title }}


### PR DESCRIPTION
## Summary
- fix document writer link to use absolute path

## Testing
- `npm run build` *(fails: Could not initialize provider google)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f9f868d083248f677edb3ab94e7d