### PR TITLE
feat: add theme config and base ui components

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,11 @@
+export default defineAppConfig({
+  ui: {
+    primary: 'primary',
+    gray: 'neutral',
+    radius: 'md',
+    font: {
+      sans: 'var(--font-sans)',
+      mono: 'var(--font-mono, monospace)'
+    }
+  }
+})

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,23 +1,43 @@
 @import "tailwindcss";
 
+:root {
+  --color-primary: 14 165 233;
+  --color-secondary: 251 207 232;
+  --color-accent: 254 249 195;
+  --color-background: 248 250 252;
+  --color-text: 55 65 81;
+  --radius: 0.5rem;
+  --font-sans: 'Inter', sans-serif;
+  --font-mono: 'Fira Code', monospace;
+}
+
+.dark {
+  --color-primary: 2 132 199;
+  --color-secondary: 244 114 182;
+  --color-accent: 250 204 21;
+  --color-background: 15 23 42;
+  --color-text: 248 250 252;
+}
+
 @layer base {
   body {
-    @apply bg-background text-text;
-  }
-
-  button {
-    @apply bg-primary text-white rounded-md px-4 py-2 transition-colors hover:bg-primary/90;
+    background-color: rgb(var(--color-background));
+    color: rgb(var(--color-text));
+    font-family: var(--font-sans);
   }
 
   table {
-    @apply w-full bg-white rounded-md shadow-sm;
+    @apply w-full bg-white rounded shadow-sm;
   }
 
   th {
-    @apply bg-secondary text-text px-4 py-2 text-left;
+    background-color: rgb(var(--color-secondary));
+    color: rgb(var(--color-text));
+    @apply px-4 py-2 text-left;
   }
 
   td {
-    @apply border-t border-secondary/60 px-4 py-2;
+    border-top: 1px solid rgba(var(--color-secondary) / 0.6);
+    @apply px-4 py-2;
   }
 }

--- a/components/ui/Button.vue
+++ b/components/ui/Button.vue
@@ -1,0 +1,14 @@
+<template>
+  <button
+    :type="type"
+    class="px-4 py-2 font-medium bg-primary text-white rounded hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-60 disabled:cursor-not-allowed"
+    v-bind="$attrs"
+  >
+    <slot />
+  </button>
+</template>
+
+<script setup lang="ts">
+const props = withDefaults(defineProps<{ type?: string }>(), { type: 'button' })
+const { type } = toRefs(props)
+</script>

--- a/components/ui/Form.vue
+++ b/components/ui/Form.vue
@@ -1,0 +1,14 @@
+<template>
+  <form
+    class="space-y-4"
+    @submit.prevent="onSubmit"
+    v-bind="$attrs"
+  >
+    <slot />
+  </form>
+</template>
+
+<script setup lang="ts">
+const emit = defineEmits(['submit'])
+const onSubmit = (e: Event) => emit('submit', e)
+</script>

--- a/components/ui/Input.vue
+++ b/components/ui/Input.vue
@@ -1,0 +1,14 @@
+<template>
+  <input
+    :value="modelValue"
+    @input="onInput"
+    class="w-full px-4 py-2 border rounded bg-background text-text focus:outline-none focus:ring-2 focus:ring-primary"
+    v-bind="$attrs"
+  />
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ modelValue?: string | number }>()
+const emit = defineEmits(['update:modelValue'])
+const onInput = (e: Event) => emit('update:modelValue', (e.target as HTMLInputElement).value)
+</script>

--- a/components/ui/Label.vue
+++ b/components/ui/Label.vue
@@ -1,0 +1,3 @@
+<template>
+  <label class="block text-sm font-medium text-text mb-1" v-bind="$attrs"><slot /></label>
+</template>

--- a/components/ui/Select.vue
+++ b/components/ui/Select.vue
@@ -1,0 +1,16 @@
+<template>
+  <select
+    :value="modelValue"
+    @change="onChange"
+    class="w-full px-4 py-2 border rounded bg-background text-text focus:outline-none focus:ring-2 focus:ring-primary"
+    v-bind="$attrs"
+  >
+    <slot />
+  </select>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ modelValue?: string | number }>()
+const emit = defineEmits(['update:modelValue'])
+const onChange = (e: Event) => emit('update:modelValue', (e.target as HTMLSelectElement).value)
+</script>

--- a/components/ui/Textarea.vue
+++ b/components/ui/Textarea.vue
@@ -1,0 +1,14 @@
+<template>
+  <textarea
+    :value="modelValue"
+    @input="onInput"
+    class="w-full px-4 py-2 border rounded bg-background text-text focus:outline-none focus:ring-2 focus:ring-primary"
+    v-bind="$attrs"
+  />
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ modelValue?: string }>()
+const emit = defineEmits(['update:modelValue'])
+const onInput = (e: Event) => emit('update:modelValue', (e.target as HTMLTextAreaElement).value)
+</script>

--- a/pages/sprint/create.vue
+++ b/pages/sprint/create.vue
@@ -7,13 +7,12 @@
         <div class="bg-white p-6 rounded-xl shadow-lg">
           <h2 class="text-2xl font-bold text-sky-700 mb-6">🌀 Yeni Sprint Oluştur</h2>
 
-          <form class="space-y-6" @submit.prevent="submitSprint">
+          <UiForm class="space-y-6" @submit="submitSprint">
             <!-- Proje Seçimi -->
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Proje Seç</label>
-              <select
+              <UiLabel>Proje Seç</UiLabel>
+              <UiSelect
                   v-model="form.projectId"
-                  class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 focus:outline-none focus:ring-2 focus:ring-sky-300"
                   :disabled="loading || submitting"
                   required
               >
@@ -37,69 +36,62 @@
                 >
                   {{ project.name }}
                 </option>
-              </select>
+              </UiSelect>
             </div>
 
             <!-- Sprint Adı -->
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Sprint Adı</label>
-              <input
+              <UiLabel>Sprint Adı</UiLabel>
+              <UiInput
                   v-model="form.name"
                   type="text"
                   placeholder="Örn: Sprint 14 - Haziran"
-                  class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 focus:outline-none focus:ring-2 focus:ring-sky-300"
                   :disabled="submitting"
                   required
-              >
+              />
             </div>
 
             <!-- Tarihler -->
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Başlangıç Tarihi</label>
-                <input
+                <UiLabel>Başlangıç Tarihi</UiLabel>
+                <UiInput
                     v-model="form.startDate"
                     type="date"
-                    class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 focus:outline-none focus:ring-2 focus:ring-sky-300"
                     :disabled="submitting"
                     required
-                >
+                />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Bitiş Tarihi</label>
-                <input
+                <UiLabel>Bitiş Tarihi</UiLabel>
+                <UiInput
                     v-model="form.endDate"
                     type="date"
-                    class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 focus:outline-none focus:ring-2 focus:ring-sky-300"
                     :disabled="submitting"
                     required
-                >
+                />
               </div>
             </div>
 
             <!-- Sprint Hedefi -->
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Sprint Hedefi (isteğe bağlı)</label>
-              <textarea
+              <UiLabel>Sprint Hedefi (isteğe bağlı)</UiLabel>
+              <UiTextarea
                   v-model="form.goal"
                   rows="3"
                   placeholder="Bu sprintte yapılacak ana işler..."
-                  class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 focus:outline-none focus:ring-2 focus:ring-sky-300 resize-none"
+                  class="resize-none"
                   :disabled="submitting"
               />
             </div>
 
             <!-- Buton -->
             <div class="flex justify-end">
-              <button
-                  type="submit"
-                  :disabled="submitting || loading"
-                  class="bg-sky-600 hover:bg-sky-700 disabled:opacity-60 disabled:cursor-not-allowed text-white font-semibold px-6 py-2 rounded-xl shadow transition"
-              >
+              <UiButton type="submit" :disabled="submitting || loading">
                 {{ submitting ? 'Oluşturuluyor…' : 'Sprint Oluştur' }}
-              </button>
+              </UiButton>
             </div>
-          </form>
+          </UiForm>
         </div>
       </div>
     </main>

--- a/pages/users/create.vue
+++ b/pages/users/create.vue
@@ -11,23 +11,23 @@
 
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-6">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Ad</label>
-              <input v-model="form.firstName" type="text" class="input" placeholder="Ad girin" />
+              <UiLabel>Ad</UiLabel>
+              <UiInput v-model="form.firstName" type="text" placeholder="Ad girin" />
             </div>
 
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Soyad</label>
-              <input v-model="form.lastName" type="text" class="input" placeholder="Soyad girin" />
+              <UiLabel>Soyad</UiLabel>
+              <UiInput v-model="form.lastName" type="text" placeholder="Soyad girin" />
             </div>
 
             <div class="sm:col-span-2">
-              <label class="block text-sm font-medium text-gray-700 mb-1">E-posta</label>
-              <input v-model="form.email" type="email" class="input" placeholder="ornek@mail.com" />
+              <UiLabel>E-posta</UiLabel>
+              <UiInput v-model="form.email" type="email" placeholder="ornek@mail.com" />
             </div>
 
             <div class="sm:col-span-2">
-              <label class="block text-sm font-medium text-gray-700 mb-1">Rol</label>
-              <select v-model="form.role" class="input">
+              <UiLabel>Rol</UiLabel>
+              <UiSelect v-model="form.role">
                 <option value="" disabled>Rol seçin</option>
                 <option
                     v-for="role in roles"
@@ -36,17 +36,12 @@
                 >
                   {{ roleLabels[role] }}
                 </option>
-              </select>
+              </UiSelect>
             </div>
           </div>
 
           <div class="pt-4">
-            <button
-                class="px-6 py-2 rounded-xl bg-sky-600 hover:bg-sky-700 text-white font-semibold shadow"
-                @click="createUser"
-            >
-              Oluştur
-            </button>
+            <UiButton @click="createUser">Oluştur</UiButton>
           </div>
         </div>
       </div>
@@ -111,11 +106,3 @@ const createUser = async () => {
   }
 }
 </script>
-
-<style scoped>
-@reference 'tailwindcss';
-
-.input {
-  @apply w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 focus:outline-none focus:ring-2 focus:ring-sky-300;
-}
-</style>

--- a/pages/users/update.vue
+++ b/pages/users/update.vue
@@ -15,21 +15,13 @@
               </div>
 
               <div class="flex items-center gap-3">
-                <select
-                    v-model="user.role"
-                    class="px-3 py-2 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-sky-300"
-                >
+                <UiSelect v-model="user.role">
                   <option v-for="role in roles" :key="role" :value="role">
                     {{ role }}
                   </option>
-                </select>
+                </UiSelect>
 
-                <button
-                    @click="updateRole(user)"
-                    class="bg-sky-600 hover:bg-sky-700 text-white font-semibold px-4 py-2 rounded-xl transition"
-                >
-                  Kaydet
-                </button>
+                <UiButton @click="updateRole(user)">Kaydet</UiButton>
               </div>
             </div>
           </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,14 +1,24 @@
 import type { Config } from 'tailwindcss'
 
 export default {
+  darkMode: 'class',
   theme: {
     extend: {
       colors: {
-        primary: '#a5b4fc',
-        secondary: '#fbcfe8',
-        accent: '#fef9c3',
-        background: '#f8fafc',
-        text: '#374151'
+        primary: 'rgb(var(--color-primary) / <alpha-value>)',
+        secondary: 'rgb(var(--color-secondary) / <alpha-value>)',
+        accent: 'rgb(var(--color-accent) / <alpha-value>)',
+        background: 'rgb(var(--color-background) / <alpha-value>)',
+        text: 'rgb(var(--color-text) / <alpha-value>)'
+      },
+      borderRadius: {
+        DEFAULT: 'var(--radius)',
+        md: 'var(--radius)',
+        lg: 'calc(var(--radius) * 1.5)'
+      },
+      fontFamily: {
+        sans: 'var(--font-sans)',
+        mono: 'var(--font-mono, monospace)'
       }
     }
   },


### PR DESCRIPTION
## Summary
- configure @nuxt/ui theme with primary color, radius and fonts
- add reusable Button, Input, Textarea, Select, Label and Form components with Tailwind styling
- support light/dark themes via CSS variables and refactor forms to use new components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c413b54c108324a4603c7aa13fd809