### PR TITLE
feat: ensure text fields render black

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -40,4 +40,8 @@
     border-top: 1px solid rgba(var(--color-secondary) / 0.6);
     @apply px-4 py-2;
   }
+
+  input, textarea {
+    color: #000;
+  }
 }

--- a/components/ui/Input.vue
+++ b/components/ui/Input.vue
@@ -2,7 +2,7 @@
   <input
     :value="modelValue"
     @input="onInput"
-    class="w-full px-4 py-2 border rounded bg-background text-text focus:outline-none focus:ring-2 focus:ring-primary"
+    class="w-full px-4 py-2 border rounded bg-background text-black focus:outline-none focus:ring-2 focus:ring-primary"
     v-bind="$attrs"
   />
 </template>

--- a/components/ui/Textarea.vue
+++ b/components/ui/Textarea.vue
@@ -2,7 +2,7 @@
   <textarea
     :value="modelValue"
     @input="onInput"
-    class="w-full px-4 py-2 border rounded bg-background text-text focus:outline-none focus:ring-2 focus:ring-primary"
+    class="w-full px-4 py-2 border rounded bg-background text-black focus:outline-none focus:ring-2 focus:ring-primary"
     v-bind="$attrs"
   />
 </template>

--- a/pages/components/dashboard/taskCreate.vue
+++ b/pages/components/dashboard/taskCreate.vue
@@ -63,7 +63,7 @@
       <label class="block">
         <input
             v-model="userSearch"
-            class="mb-2 w-full rounded px-2 py-1 border border-gray-300 focus:ring-2 focus:ring-blue-200"
+            class="mb-2 w-full rounded px-2 py-1 border border-gray-300 text-black focus:ring-2 focus:ring-blue-200"
             placeholder="Kişi ara..."
             autocomplete="off"
             type="text"
@@ -135,7 +135,7 @@
         <input
             v-model="newTaskDeadline"
             type="date"
-            class="rounded-md bg-gray-100 px-3 py-2 font-medium text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            class="rounded-md bg-gray-100 px-3 py-2 font-medium text-black placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
         >
       </label>
 
@@ -143,7 +143,7 @@
       <input
           v-model="newTaskTitle"
           placeholder="Yeni görev başlığı"
-          class="rounded-md bg-gray-100 px-3 py-2 font-medium text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+          class="rounded-md bg-gray-100 px-3 py-2 font-medium text-black placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
       >
 
       <!-- Açıklama -->
@@ -151,7 +151,7 @@
           v-model="newTaskDesc"
           rows="10"
           placeholder="Açıklama"
-          class="rounded-md bg-gray-100 px-3 py-2 resize-none border border-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-200 min-h-[300px]"
+          class="rounded-md bg-gray-100 px-3 py-2 resize-none border border-gray-200 text-black focus:outline-none focus:ring-2 focus:ring-blue-200 min-h-[300px]"
       />
 
       <!-- Görev Oluştur Butonu -->
@@ -196,7 +196,7 @@
           v-model="bulkJson"
           rows="16"
           spellcheck="false"
-          class="rounded-md bg-gray-100 px-3 py-2 border border-gray-200 focus:outline-none focus:ring-2 focus:ring-blue-200 font-mono text-sm"
+          class="rounded-md bg-gray-100 px-3 py-2 border border-gray-200 text-black focus:outline-none focus:ring-2 focus:ring-blue-200 font-mono text-sm"
           placeholder='[ { "title": "…", "assignedTo": 1, "project": 1 } ]'
       />
 

--- a/pages/components/sprint/SprintTaskAssignment.vue
+++ b/pages/components/sprint/SprintTaskAssignment.vue
@@ -28,7 +28,7 @@
               v-model="selectedTaskIds"
               type="checkbox"
               :value="task.id"
-              class="accent-sky-600 w-4 h-4"
+              class="accent-sky-600 w-4 h-4 text-black"
           >
           <span class="text-gray-700">{{ task.title }}</span>
         </div>

--- a/pages/customers/create.vue
+++ b/pages/customers/create.vue
@@ -22,25 +22,25 @@
           <form class="space-y-6" @submit.prevent="submitCustomer">
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Firma Adı</label>
-              <input v-model="form.firmaAdi" type="text" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50" required >
+              <input v-model="form.firmaAdi" type="text" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 text-black" required >
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Yetkili Kişi</label>
-              <input v-model="form.yetkiliKisi" type="text" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50" required >
+              <input v-model="form.yetkiliKisi" type="text" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 text-black" required >
             </div>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                <input v-model="form.email" type="email" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50" >
+                <input v-model="form.email" type="email" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 text-black" >
               </div>
               <div>
                 <label class="block text-sm font-medium text-gray-700 mb-1">Telefon</label>
-                <input v-model="form.telefon" type="text" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50" >
+                <input v-model="form.telefon" type="text" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 text-black" >
               </div>
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Notlar</label>
-              <textarea v-model="form.notlar" rows="3" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 resize-none" />
+              <textarea v-model="form.notlar" rows="3" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 resize-none text-black" />
             </div>
             <div class="flex justify-end">
               <button type="submit" class="bg-sky-600 hover:bg-sky-700 text-white font-semibold px-6 py-2 rounded-xl shadow">
@@ -56,7 +56,7 @@
               v-model="searchQuery"
               type="text"
               placeholder="Müşteri ara..."
-              class="flex-1 px-4 py-2 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-sky-300"
+              class="flex-1 px-4 py-2 rounded-lg border border-gray-300 bg-white text-black focus:outline-none focus:ring-2 focus:ring-sky-300"
           />
           <button class="bg-sky-600 text-white px-5 py-2 rounded-lg shadow hover:bg-sky-700">
             + Müşteri bul
@@ -86,12 +86,12 @@
               <button @click="selectedCustomer = null" class="text-gray-400 hover:text-gray-600">✕</button>
             </div>
             <form class="space-y-4" @submit.prevent="updateCustomer">
-              <input v-model="selectedCustomer.firmaAdi" type="text" class="w-full px-4 py-2 rounded border border-gray-300" placeholder="Firma Adı" required />
-              <input v-model="selectedCustomer.yetkiliKisi" type="text" class="w-full px-4 py-2 rounded border border-gray-300" placeholder="Yetkili Kişi" required />
-              <input v-model="selectedCustomer.email" type="email" class="w-full px-4 py-2 rounded border border-gray-300" placeholder="Email" />
-              <input v-model="selectedCustomer.telefon" type="text" class="w-full px-4 py-2 rounded border border-gray-300" placeholder="Telefon" />
+              <input v-model="selectedCustomer.firmaAdi" type="text" class="w-full px-4 py-2 rounded border border-gray-300 text-black" placeholder="Firma Adı" required />
+              <input v-model="selectedCustomer.yetkiliKisi" type="text" class="w-full px-4 py-2 rounded border border-gray-300 text-black" placeholder="Yetkili Kişi" required />
+              <input v-model="selectedCustomer.email" type="email" class="w-full px-4 py-2 rounded border border-gray-300 text-black" placeholder="Email" />
+              <input v-model="selectedCustomer.telefon" type="text" class="w-full px-4 py-2 rounded border border-gray-300 text-black" placeholder="Telefon" />
               <label class="block text-sm font-medium text-gray-700">Açıklama / Hikaye</label>
-              <textarea v-model="selectedCustomer.notlar" rows="5" class="w-full px-4 py-2 rounded border border-gray-300 resize-none bg-blue-50"></textarea>
+              <textarea v-model="selectedCustomer.notlar" rows="5" class="w-full px-4 py-2 rounded border border-gray-300 resize-none bg-blue-50 text-black"></textarea>
               <div class="flex justify-end">
                 <button type="submit" class="bg-sky-600 text-white px-6 py-2 rounded shadow hover:bg-sky-700">
                   Kaydet

--- a/pages/documents/TreeItem.vue
+++ b/pages/documents/TreeItem.vue
@@ -31,7 +31,7 @@
           v-model="newTitle"
           @keydown.enter="addChild"
           placeholder="Alt başlık yazın ve Enter’a basın"
-          class="w-full px-2 py-1 text-sm border rounded focus:outline-none focus:ring"
+          class="w-full px-2 py-1 text-sm border rounded text-black focus:outline-none focus:ring"
       />
     </div>
 

--- a/pages/documents/list.vue
+++ b/pages/documents/list.vue
@@ -36,7 +36,7 @@
             <input
                 v-model="newRootTitle"
                 placeholder="Ana doküman başlığı"
-                class="px-3 py-2 border rounded w-full focus:outline-none focus:ring"
+                class="px-3 py-2 border rounded w-full text-black focus:outline-none focus:ring"
             />
             <button
                 @click="addRootDocument"

--- a/pages/documents/writer/[id].vue
+++ b/pages/documents/writer/[id].vue
@@ -83,8 +83,8 @@ async function updateDocument() {
             </div>
           </div>
 
-          <input v-model="doc.title" type="text" placeholder="Başlık..." class="w-full text-3xl font-extrabold border-0 border-b-2 border-sky-100 focus:border-sky-500 bg-transparent px-1 mb-3 py-3 outline-none transition">
-          <input v-model="doc.desc" type="text" placeholder="Özet (isteğe bağlı)..." class="w-full text-lg font-medium border-0 border-b border-gray-100 focus:border-sky-500 bg-transparent px-1 mb-8 py-2 outline-none transition text-gray-500">
+          <input v-model="doc.title" type="text" placeholder="Başlık..." class="w-full text-3xl font-extrabold border-0 border-b-2 border-sky-100 focus:border-sky-500 bg-transparent px-1 mb-3 py-3 outline-none transition text-black">
+          <input v-model="doc.desc" type="text" placeholder="Özet (isteğe bağlı)..." class="w-full text-lg font-medium border-0 border-b border-gray-100 focus:border-sky-500 bg-transparent px-1 mb-8 py-2 outline-none transition text-black">
           <CkEditor v-model="doc.content" class="ProseMirror-Word" />
 
           <p v-if="successMessage" class="text-green-600 mt-4">{{ successMessage }}</p>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -18,11 +18,11 @@ d="M32 16 C38 10, 54 20, 38 32 Q32 38, 26 32 C10 20, 26 10, 32 16 Z"
       <form class="w-full space-y-5" @submit.prevent="login">
         <div>
           <label class="block text-sm font-semibold text-gray-700 mb-1">Eposta</label>
-          <input v-model="email" type="text" placeholder="eposta gir" class="input-field" required >
+          <input v-model="email" type="text" placeholder="eposta gir" class="input-field text-black" required >
         </div>
         <div>
           <label class="block text-sm font-semibold text-gray-700 mb-1">Şifre</label>
-          <input v-model="password" type="password" placeholder="••••••••" class="input-field" required >
+          <input v-model="password" type="password" placeholder="••••••••" class="input-field text-black" required >
         </div>
 
         <button

--- a/pages/projects/create.vue
+++ b/pages/projects/create.vue
@@ -19,11 +19,11 @@
         <!-- Etiket Ekleme Formu -->
         <div class="mb-6">
           <div class="flex items-center gap-2">
-            <input 
-              v-model="newLabelName" 
-              type="text" 
-              placeholder="Yeni etiket adı" 
-              class="flex-1 p-2 border rounded-lg"
+            <input
+              v-model="newLabelName"
+              type="text"
+              placeholder="Yeni etiket adı"
+              class="flex-1 p-2 border rounded-lg text-black"
             />
             <button 
               @click="createLabel" 
@@ -82,7 +82,7 @@
                   v-model="form.title"
                   type="text"
                   required
-                  class="w-full mt-1 p-2 border rounded-lg"
+                  class="w-full mt-1 p-2 border rounded-lg text-black"
               />
             </div>
 
@@ -92,7 +92,7 @@
                   v-model="form.description"
                   rows="4"
                   required
-                  class="w-full mt-1 p-2 border rounded-lg"
+                  class="w-full mt-1 p-2 border rounded-lg text-black"
               />
             </div>
 
@@ -102,7 +102,7 @@
                   v-model="form.startDate"
                   type="date"
                   required
-                  class="w-full mt-1 p-2 border rounded-lg"
+                  class="w-full mt-1 p-2 border rounded-lg text-black"
               />
             </div>
 

--- a/pages/tasks/[id].vue
+++ b/pages/tasks/[id].vue
@@ -117,7 +117,7 @@
             <textarea
               v-model="newComment"
               rows="4"
-              class="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-200"
+              class="w-full p-3 border border-gray-300 rounded-md text-black focus:ring-2 focus:ring-blue-200"
               placeholder="Yorumunuzu yazın..."
             />
             <button


### PR DESCRIPTION
## Summary
- enforce black text color for input and textarea elements in base CSS
- swap `text-text` utility for `text-black` in Input and Textarea components
- append `text-black` to direct `<input>` and `<textarea>` usages across pages

## Testing
- `npm run build` *(fails: Could not initialize provider google. unifont will not be able to process fonts provided by this provider. fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6eac28c488324a8712c2868b5c6e2