### PR TITLE
feat: add shared UI theme components

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -45,3 +45,36 @@
     color: #000;
   }
 }
+
+@layer components {
+  .btn {
+    @apply px-4 py-2 font-medium text-white rounded hover:opacity-90 focus:outline-none focus:ring-2 disabled:opacity-60 disabled:cursor-not-allowed;
+    background-color: rgb(var(--color-primary));
+    --tw-ring-color: rgb(var(--color-primary));
+  }
+
+  .input {
+    @apply w-full px-4 py-2 border rounded text-black focus:outline-none focus:ring-2;
+    background-color: rgb(var(--color-background));
+    --tw-ring-color: rgb(var(--color-primary));
+  }
+
+  .text-base-style {
+    @apply text-base leading-relaxed;
+    color: rgb(var(--color-text));
+  }
+
+  .faq-item {
+    @apply border-b py-4;
+    border-color: rgb(var(--color-secondary));
+  }
+
+  .faq-question {
+    @apply flex justify-between items-center cursor-pointer font-medium;
+  }
+
+  .faq-answer {
+    @apply mt-2 text-sm;
+    color: rgb(var(--color-text));
+  }
+}

--- a/components/ui/Button.vue
+++ b/components/ui/Button.vue
@@ -1,7 +1,7 @@
 <template>
   <button
     :type="type"
-    class="px-4 py-2 font-medium bg-primary text-white rounded hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-60 disabled:cursor-not-allowed"
+    class="btn"
     v-bind="$attrs"
   >
     <slot />

--- a/components/ui/Faq.vue
+++ b/components/ui/Faq.vue
@@ -1,0 +1,12 @@
+<template>
+  <div>
+    <details v-for="(item, index) in items" :key="index" class="faq-item">
+      <summary class="faq-question">{{ item.question }}</summary>
+      <p class="faq-answer">{{ item.answer }}</p>
+    </details>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ items: { question: string; answer: string }[] }>()
+</script>

--- a/components/ui/Input.vue
+++ b/components/ui/Input.vue
@@ -2,7 +2,7 @@
   <input
     :value="modelValue"
     @input="onInput"
-    class="w-full px-4 py-2 border rounded bg-background text-black focus:outline-none focus:ring-2 focus:ring-primary"
+    class="input"
     v-bind="$attrs"
   />
 </template>

--- a/components/ui/Text.vue
+++ b/components/ui/Text.vue
@@ -1,0 +1,5 @@
+<template>
+  <p class="text-base-style" v-bind="$attrs">
+    <slot />
+  </p>
+</template>


### PR DESCRIPTION
## Summary
- add reusable button, input, text and FAQ theme classes in Tailwind
- simplify Button and Input components to use shared classes
- add Text and Faq components for consistent typography and FAQ sections

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6fc51a8948324a6263602141a9339