### PR TITLE
Set default text color to black

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -5,7 +5,7 @@
   --color-secondary: 251 207 232;
   --color-accent: 254 249 195;
   --color-background: 248 250 252;
-  --color-text: 55 65 81;
+  --color-text: 0 0 0;
   --radius: 0.5rem;
   --font-sans: 'Inter', sans-serif;
   --font-mono: 'Fira Code', monospace;
@@ -16,7 +16,7 @@
   --color-secondary: 244 114 182;
   --color-accent: 250 204 21;
   --color-background: 15 23 42;
-  --color-text: 248 250 252;
+  --color-text: 255 255 255;
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
- default text color set to black for better contrast
- ensure dark theme uses white text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c71b3358e88324bcc09479d4284686