### PR TITLE
Replace gray text utilities with text-black

### DIFF
--- a/pages/components/bar/Footer.vue
+++ b/pages/components/bar/Footer.vue
@@ -1,6 +1,6 @@
 <template>
   <footer class="bg-white border-t border-gray-200 mt-12 py-6">
-    <div class="max-w-6xl mx-auto px-4 flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-gray-500">
+    <div class="max-w-6xl mx-auto px-4 flex flex-col md:flex-row justify-between items-center gap-4 text-sm text-black">
 
       <!-- Sol kısım -->
       <div class="flex items-center gap-2">

--- a/pages/components/bar/Navbar.vue
+++ b/pages/components/bar/Navbar.vue
@@ -88,8 +88,8 @@
       <!-- Kullanıcı Profili -->
       <div v-if="isLoggedName" class="relative" @mouseenter="showProfileMenu = true" @mouseleave="delayedClose('profile')">
         <button class="flex items-center gap-2 px-2 py-1 rounded-lg hover:bg-sky-100 transition">
-          <span class="font-semibold text-gray-700 hidden sm:inline">{{ user?.name }}</span>
-          <svg class="w-4 h-4 text-gray-400 ml-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7" /></svg>
+          <span class="font-semibold text-black hidden sm:inline">{{ user?.name }}</span>
+          <svg class="w-4 h-4 text-black ml-1" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M19 9l-7 7-7-7" /></svg>
         </button>
         <div v-if="showProfileMenu" class="dropdown-panel right-0" @mouseenter="cancelClose('profile')" @mouseleave="delayedClose('profile')">
           <button class="dropdown-item text-red-600" @click="logout">Çıkış Yap</button>
@@ -112,7 +112,7 @@
     <NuxtLink to="/documents/list" class="block py-2 nav-link">Döküman Yaz</NuxtLink>
 
     <div v-if="canSeeSprintMenu" class="mt-4">
-      <p class="font-semibold text-gray-700 mb-2">Sprint Yönetimi</p>
+      <p class="font-semibold text-black mb-2">Sprint Yönetimi</p>
       <NuxtLink
           v-for="item in sprintMenuItems"
           :key="item.to"
@@ -122,13 +122,13 @@
     </div>
 
     <div v-if="canSeeProjectMenu" class="mt-4">
-      <p class="font-semibold text-gray-700 mb-2">Proje Yönetimi</p>
+      <p class="font-semibold text-black mb-2">Proje Yönetimi</p>
       <NuxtLink to="/projects/create" class="block py-1 pl-4 nav-link">Proje Oluştur</NuxtLink>
       <NuxtLink to="/projects/members" class="block py-1 pl-4 nav-link">Katılımcılar</NuxtLink>
     </div>
 
     <div v-if="canSeeCustomerMenu" class="mt-4">
-      <p class="font-semibold text-gray-700 mb-2">Müşteri Yönetimi</p>
+      <p class="font-semibold text-black mb-2">Müşteri Yönetimi</p>
       <NuxtLink
           v-if="user?.role !== 'marketer'"
           to="/customers/create"
@@ -138,7 +138,7 @@
     </div>
 
     <div v-if="canSeeUserMenu" class="mt-4">
-      <p class="font-semibold text-gray-700 mb-2">Kullanıcı Yönetimi</p>
+      <p class="font-semibold text-black mb-2">Kullanıcı Yönetimi</p>
       <NuxtLink to="/users/create" class="block py-1 pl-4 nav-link">Kullanıcı Oluştur</NuxtLink>
       <NuxtLink to="/users/update" class="block py-1 pl-4 nav-link">Kullanıcı rol güncelle</NuxtLink>
     </div>

--- a/pages/components/dashboard/DashboardDrawer.vue
+++ b/pages/components/dashboard/DashboardDrawer.vue
@@ -2,7 +2,7 @@
   <transition name="slide">
     <div v-if="true" class="fixed inset-0 bg-white z-50 md:hidden overflow-y-auto">
       <div class="p-4">
-        <button class="mb-4 text-gray-500" @click="$emit('close')">
+        <button class="mb-4 text-black" @click="$emit('close')">
           Kapat
         </button>
         <NotificationsPanel

--- a/pages/components/dashboard/commentList.vue
+++ b/pages/components/dashboard/commentList.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="bg-white rounded-xl p-4 flex flex-col gap-4">
-    <div class="flex items-center gap-2 text-lg font-semibold text-gray-700 mb-2">
+    <div class="flex items-center gap-2 text-lg font-semibold text-black mb-2">
       <svg class="w-6 h-6 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path d="M17 8h2a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V10a2 2 0 012-2h2" stroke-width="2"/><path d="M15 3h-6a2 2 0 00-2 2v4h10V5a2 2 0 00-2-2z" stroke-width="2"/><circle cx="12" cy="14" r="2" stroke-width="2"/></svg>
       Yorumlar
     </div>
@@ -14,14 +14,14 @@
             </svg>
           </div>
           <div>
-            <div class="font-semibold text-gray-800">{{ c.author }}</div>
-            <div class="text-sm text-gray-700">{{ c.text }}</div>
-            <div class="text-xs text-gray-400 mt-1">{{ c.time }}</div>
+            <div class="font-semibold text-black">{{ c.author }}</div>
+            <div class="text-sm text-black">{{ c.text }}</div>
+            <div class="text-xs text-black mt-1">{{ c.time }}</div>
           </div>
         </li>
       </template>
       <template v-else>
-        <li class="text-gray-400 text-center py-6 select-none">
+        <li class="text-black text-center py-6 select-none">
           Henüz bir yorum yok.
         </li>
       </template>

--- a/pages/components/dashboard/notifications.vue
+++ b/pages/components/dashboard/notifications.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="bg-white rounded-xl p-4 flex flex-col gap-4">
-    <div class="flex items-center gap-2 text-lg font-semibold text-gray-700 mb-2">
+    <div class="flex items-center gap-2 text-lg font-semibold text-black mb-2">
       <svg class="w-6 h-6 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6 6 0 10-12 0v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 01-6 0v-1m6 0H9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
@@ -19,13 +19,13 @@
             <path d="M9 12l2 2 4-4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
           </svg>
           <div class="flex-1">
-            <div class="text-sm text-gray-800">{{ n.message }}</div>
-            <div class="text-xs text-gray-400 mt-1">{{ n.time }}</div>
+            <div class="text-sm text-black">{{ n.message }}</div>
+            <div class="text-xs text-black mt-1">{{ n.time }}</div>
           </div>
         </li>
       </template>
       <template v-else>
-        <li class="text-gray-400 text-center py-6 select-none">
+        <li class="text-black text-center py-6 select-none">
           Henüz bir bildirim yok.
         </li>
       </template>

--- a/pages/components/dashboard/taskCreate.vue
+++ b/pages/components/dashboard/taskCreate.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="bg-white rounded-xl p-4 shadow flex flex-col gap-4 h-full overflow-y-auto min-h-0">
     <!-- Başlık -->
-    <div class="flex items-center gap-2 mb-2 text-xl font-bold text-gray-700">
+    <div class="flex items-center gap-2 mb-2 text-xl font-bold text-black">
       <svg class="w-6 h-6 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path d="M4 7h16M4 12h8m-8 5h16" stroke-width="2" stroke-linecap="round"/>
       </svg>
@@ -14,7 +14,7 @@
           class="px-4 py-2 -mb-px border-b-2"
           :class="activeTab === 'single'
           ? 'border-blue-500 text-blue-600 font-semibold'
-          : 'border-transparent text-gray-500 hover:text-gray-700'"
+          : 'border-transparent text-black hover:text-black'"
           @click="activeTab = 'single'"
       >
         Tekil Oluştur
@@ -23,7 +23,7 @@
           class="px-4 py-2 -mb-px border-b-2"
           :class="activeTab === 'bulk'
           ? 'border-blue-500 text-blue-600 font-semibold'
-          : 'border-transparent text-gray-500 hover:text-gray-700'"
+          : 'border-transparent text-black hover:text-black'"
           @click="activeTab = 'bulk'"
       >
         Toplu (JSON)
@@ -34,10 +34,10 @@
     <div v-if="activeTab === 'single'" class="flex flex-col gap-4">
       <!-- Proje Seç -->
       <label class="block">
-        <span class="block text-gray-700 text-base font-semibold mb-1">Proje Seç</span>
+        <span class="block text-black text-base font-semibold mb-1">Proje Seç</span>
         <select
             v-model="selectedProject"
-            class="block w-full mt-1 rounded-md border border-gray-300 bg-gray-100 text-gray-700 shadow-sm px-3 py-2"
+            class="block w-full mt-1 rounded-md border border-gray-300 bg-gray-100 text-black shadow-sm px-3 py-2"
         >
           <option value="">Proje seçiniz</option>
           <option v-for="p in projects" :key="p.id" :value="String(p.id)">{{ p.name }}</option>
@@ -46,10 +46,10 @@
 
       <!-- Tür -->
       <label class="block">
-        <span class="block text-gray-700 text-base font-semibold mb-1">Tür</span>
+        <span class="block text-black text-base font-semibold mb-1">Tür</span>
         <select
             v-model="newTaskType"
-            class="block w-full mt-1 rounded-md border border-gray-300 bg-gray-50 text-gray-700 shadow-sm px-3 py-2"
+            class="block w-full mt-1 rounded-md border border-gray-300 bg-gray-50 text-black shadow-sm px-3 py-2"
         >
           <option value="">Tür Seçiniz</option>
           <option value="task">Görev</option>
@@ -68,10 +68,10 @@
             autocomplete="off"
             type="text"
         >
-        <span class="block text-gray-700 text-base font-semibold mb-1">Atanacak Kişi</span>
+        <span class="block text-black text-base font-semibold mb-1">Atanacak Kişi</span>
         <select
             v-model="assignedUser"
-            class="block w-full mt-1 rounded-md border border-gray-300 bg-gray-50 text-gray-700 shadow-sm px-3 py-2"
+            class="block w-full mt-1 rounded-md border border-gray-300 bg-gray-50 text-black shadow-sm px-3 py-2"
         >
           <option value="" disabled>Kişi seçiniz</option>
           <option v-for="user in filteredUsers" :key="user.id" :value="String(user.id)">{{ user.name }}</option>
@@ -80,10 +80,10 @@
 
       <!-- Seviye -->
       <label class="block">
-        <span class="block text-gray-700 text-base font-semibold mb-1">Seviye</span>
+        <span class="block text-black text-base font-semibold mb-1">Seviye</span>
         <select
             v-model="newTaskLevel"
-            class="block w-full mt-1 rounded-md border border-gray-300 bg-gray-50 text-gray-700 shadow-sm px-3 py-2"
+            class="block w-full mt-1 rounded-md border border-gray-300 bg-gray-50 text-black shadow-sm px-3 py-2"
         >
           <template v-if="newTaskType === 'task'">
             <option value="normal">Normal</option>
@@ -98,7 +98,7 @@
 
       <!-- Etiketler -->
       <div v-if="projectLabels.length > 0" class="block">
-        <span class="block text-gray-700 text-base font-semibold mb-1">Etiketler</span>
+        <span class="block text-black text-base font-semibold mb-1">Etiketler</span>
         <div class="flex flex-wrap gap-2 mt-1">
           <button
               v-for="label in projectLabels"
@@ -109,7 +109,7 @@
               'text-xs font-semibold px-3 py-1 rounded-full border transition-all',
               selectedLabels.includes(label.id)
                 ? 'bg-green-500 text-white border-green-600'
-                : 'bg-gray-100 text-gray-700 border-gray-200 hover:bg-green-100'
+                : 'bg-gray-100 text-black border-gray-200 hover:bg-green-100'
             ]"
           >
             {{ label.name }}
@@ -119,11 +119,11 @@
 
       <!-- Çoklu Bağlı Görev -->
       <label v-if="newTaskType === 'task'" class="block">
-        <span class="block text-gray-700 text-base font-semibold mb-1">Bağlı Görevler</span>
+        <span class="block text-black text-base font-semibold mb-1">Bağlı Görevler</span>
         <select
             v-model="bagliGorevler"
             multiple
-            class="block w-full mt-1 rounded-md border border-gray-300 bg-gray-50 text-gray-700 shadow-sm px-3 py-2 h-32"
+            class="block w-full mt-1 rounded-md border border-gray-300 bg-gray-50 text-black shadow-sm px-3 py-2 h-32"
         >
           <option v-for="g in tumGorevler" :key="g.id" :value="g.id">{{ g.title }}</option>
         </select>
@@ -131,7 +131,7 @@
 
       <!-- Deadline -->
       <label class="block">
-        <span class="block text-gray-700 text-base font-semibold mb-1">Bitiş Tarihi</span>
+        <span class="block text-black text-base font-semibold mb-1">Bitiş Tarihi</span>
         <input
             v-model="newTaskDeadline"
             type="date"
@@ -222,7 +222,7 @@
           </svg>
           Toplu Görev Oluştur
         </button>
-        <span v-if="bulkSummary" class="text-sm text-gray-600">{{ bulkSummary }}</span>
+        <span v-if="bulkSummary" class="text-sm text-black">{{ bulkSummary }}</span>
       </div>
     </div>
   </div>

--- a/pages/components/dashboard/taskList.vue
+++ b/pages/components/dashboard/taskList.vue
@@ -2,7 +2,7 @@
   <div class="bg-white rounded-xl p-4 shadow flex flex-col gap-4 h-full overflow-y-auto min-h-0">
     <!-- Başlık -->
     <div class="flex items-center justify-between mb-2">
-      <div class="flex items-center gap-2 text-lg font-semibold text-gray-700">
+      <div class="flex items-center gap-2 text-lg font-semibold text-black">
         <svg class="w-6 h-6 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <rect x="3" y="8" width="18" height="13" rx="2" stroke-width="2" />
           <path d="M16 3v4M8 3v4" stroke-width="2" stroke-linecap="round" />
@@ -33,19 +33,19 @@
       </div>
 
       <div class="flex flex-col min-w-[220px]">
-        <label class="text-sm font-medium text-gray-600 mb-1">Proje:</label>
+        <label class="text-sm font-medium text-black mb-1">Proje:</label>
         <div class="relative">
           <select
               v-model="selectedProjectId"
               @change="onProjectSelect"
-              class="appearance-none w-full bg-white border border-gray-300 text-gray-700 text-sm py-2 px-3 pr-8 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
+              class="appearance-none w-full bg-white border border-gray-300 text-black text-sm py-2 px-3 pr-8 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-300 focus:border-blue-400"
           >
             <option disabled :value="null">Proje seçiniz</option>
             <option v-for="project in projects" :key="project.id" :value="project.id">
               {{ project.name }}
             </option>
           </select>
-          <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-500">
+          <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-black">
             <svg class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
               <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 10.939l3.71-3.71a.75.75 0 011.08 1.04l-4.24 4.25a.75.75 0 01-1.08 0l-4.25-4.25a.75.75 0 01.02-1.06z" clip-rule="evenodd"/>
             </svg>
@@ -64,7 +64,7 @@
           'text-xs font-semibold px-3 py-1 rounded-full border transition-all',
           selectedLabelIds.includes(label.id)
             ? 'bg-green-500 text-white border-green-600'
-            : 'bg-gray-100 text-gray-700 border-gray-200 hover:bg-green-100'
+            : 'bg-gray-100 text-black border-gray-200 hover:bg-green-100'
         ]"
       >
         {{ label.name }}
@@ -95,10 +95,10 @@
               <span :class="[getLevelClass(task.level), 'text-xs font-bold rounded-full px-2 py-0.5']">
                 {{ getLevelLabel(task.level) }}
               </span>
-              <span v-if="task.dependentTaskId" class="bg-yellow-300 text-gray-900 text-xs font-bold rounded-full px-2 py-0.5">
+              <span v-if="task.dependentTaskId" class="bg-yellow-300 text-black text-xs font-bold rounded-full px-2 py-0.5">
                 Önce: {{ task.dependentTaskTitle || 'Bağlı görev' }}
               </span>
-              <span :class="task.status === 'Completed' ? 'line-through text-green-800' : 'text-gray-900'" class="font-medium">
+              <span :class="task.status === 'Completed' ? 'line-through text-green-800' : 'text-black'" class="font-medium">
                 {{ task.title }}
               </span>
             </div>
@@ -108,7 +108,7 @@
             <span v-else-if="task.status === 'Ready'" class="bg-blue-200 text-blue-800 text-xs rounded-full px-2 py-0.5 font-bold flex items-center gap-1">
               🔔 Başlamaya Hazır
             </span>
-            <span v-else-if="task.status === 'Waiting'" class="bg-gray-300 text-gray-700 text-xs rounded-full px-2 py-0.5 font-bold flex items-center gap-1">
+            <span v-else-if="task.status === 'Waiting'" class="bg-gray-300 text-black text-xs rounded-full px-2 py-0.5 font-bold flex items-center gap-1">
               ⏱ Beklemede
             </span>
             <span v-else-if="task.status === 'Completed'" class="bg-green-200 text-green-800 text-xs rounded-full px-2 py-0.5 font-bold flex items-center gap-1">
@@ -116,7 +116,7 @@
             </span>
           </div>
 
-          <div class="text-xs text-gray-400 mt-1">{{ task.time }}</div>
+          <div class="text-xs text-black mt-1">{{ task.time }}</div>
           <div v-if="task.formattedDeadline" class="text-xs text-blue-500 mt-1">
             Bitiş Tarihi: {{ task.formattedDeadline }}
           </div>
@@ -144,7 +144,7 @@
         </li>
       </template>
       <template v-else>
-        <li class="text-gray-400 text-center py-6 select-none">
+        <li class="text-black text-center py-6 select-none">
           Hiç görev bulunamadı.
         </li>
       </template>
@@ -153,8 +153,8 @@
     <!-- Confirm Modal -->
     <div v-if="showConfirm" class="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
       <div class="bg-white rounded-xl shadow-xl w-80 p-6 text-center">
-        <h2 class="text-lg font-semibold text-gray-700 mb-3">Görev Silinsin mi?</h2>
-        <p class="text-sm text-gray-500 mb-5">
+        <h2 class="text-lg font-semibold text-black mb-3">Görev Silinsin mi?</h2>
+        <p class="text-sm text-black mb-5">
           "{{ taskToDelete?.title }}" görevini silmek istediğine emin misin?
         </p>
         <div class="flex justify-center gap-4">
@@ -167,7 +167,7 @@
           </button>
           <button
               @click="closeConfirm"
-              class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300"
+              class="px-4 py-2 bg-gray-200 text-black rounded-lg hover:bg-gray-300"
           >
             Hayır
           </button>
@@ -224,7 +224,7 @@ function tabClass(type: string) {
     'px-4 py-2 text-sm font-semibold -mb-px border-b-2 transition-all duration-200',
     taskFilter.value === type
         ? 'border-blue-600 text-blue-600'
-        : 'border-transparent text-gray-500 hover:text-blue-600 hover:border-blue-300'
+        : 'border-transparent text-black hover:text-blue-600 hover:border-blue-300'
   ]
 }
 
@@ -394,7 +394,7 @@ function getLevelClass(level: string) {
     case 'critical': return 'bg-red-600 text-white'
     case 'urgent': return 'bg-orange-500 text-white'
     case 'priority': return 'bg-yellow-500 text-white'
-    default: return 'bg-gray-300 text-gray-800'
+    default: return 'bg-gray-300 text-black'
   }
 }
 

--- a/pages/components/sprint/SprintBurndownChart.vue
+++ b/pages/components/sprint/SprintBurndownChart.vue
@@ -6,7 +6,7 @@
       <Line :data="chartData" :options="chartOptions" class="w-full h-full" />
     </div>
 
-    <div v-else class="text-gray-400 text-sm py-8 text-center">
+    <div v-else class="text-black text-sm py-8 text-center">
       Gösterilecek veri bulunamadı.
     </div>
   </div>

--- a/pages/components/sprint/SprintMetaInfo.vue
+++ b/pages/components/sprint/SprintMetaInfo.vue
@@ -6,17 +6,17 @@
     </div>
 
     <!-- Tarihler -->
-    <p class="text-sm text-gray-600">
+    <p class="text-sm text-black">
       <strong>Tarih:</strong> {{ formatDate(sprint.startDate) }} – {{ formatDate(sprint.endDate) }}
     </p>
 
     <!-- Kalan Gün -->
-    <p class="text-sm text-gray-600">
+    <p class="text-sm text-black">
       <strong>Kalan Gün:</strong> {{ daysRemaining }} gün
     </p>
 
     <!-- Sprint Hedefi -->
-    <div v-if="sprint.goal" class="bg-blue-50 border border-blue-100 rounded-lg p-3 text-gray-700 text-sm">
+    <div v-if="sprint.goal" class="bg-blue-50 border border-blue-100 rounded-lg p-3 text-black text-sm">
       <strong>Hedef:</strong>
       <p class="mt-1">{{ sprint.goal }}</p>
     </div>

--- a/pages/components/sprint/SprintProgressBar.vue
+++ b/pages/components/sprint/SprintProgressBar.vue
@@ -3,8 +3,8 @@
     <h2 class="text-lg font-semibold text-sky-700 mb-2">📈 Sprint İlerleme Durumu</h2>
 
     <div class="flex items-center justify-between mb-2">
-      <span class="text-sm text-gray-600">Tamamlanan Görevler:</span>
-      <span class="text-sm text-gray-800 font-medium">
+      <span class="text-sm text-black">Tamamlanan Görevler:</span>
+      <span class="text-sm text-black font-medium">
         {{ completed }} / {{ total }} ({{ percent }}%)
       </span>
     </div>

--- a/pages/components/sprint/SprintTaskAssignment.vue
+++ b/pages/components/sprint/SprintTaskAssignment.vue
@@ -2,7 +2,7 @@
   <div class="bg-blue-50 p-4 rounded-lg border border-blue-100 space-y-4">
     <!-- Sprint Seç -->
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-1">Sprint Seç</label>
+      <label class="block text-sm font-medium text-black mb-1">Sprint Seç</label>
       <select
           v-model="selectedSprintId"
           class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-white focus:outline-none focus:ring-2 focus:ring-sky-300"
@@ -17,7 +17,7 @@
 
     <!-- Görev Seçimi -->
     <div>
-      <label class="block text-sm font-medium text-gray-700 mb-2">Görevler (hazır durumdakiler)</label>
+      <label class="block text-sm font-medium text-black mb-2">Görevler (hazır durumdakiler)</label>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div
             v-for="task in filteredTasks"
@@ -30,7 +30,7 @@
               :value="task.id"
               class="accent-sky-600 w-4 h-4 text-black"
           >
-          <span class="text-gray-700">{{ task.title }}</span>
+          <span class="text-black">{{ task.title }}</span>
         </div>
       </div>
     </div>

--- a/pages/components/sprint/SprintTaskList.vue
+++ b/pages/components/sprint/SprintTaskList.vue
@@ -5,8 +5,8 @@
         :key="task.id"
         class="bg-white border border-gray-200 rounded-lg px-4 py-2 shadow-sm flex justify-between items-center"
     >
-      <span class="text-gray-800 font-medium">{{ task.title }}</span>
-      <span class="text-sm text-gray-500 italic">Durum: {{ task.status }}</span>
+      <span class="text-black font-medium">{{ task.title }}</span>
+      <span class="text-sm text-black italic">Durum: {{ task.status }}</span>
     </div>
   </div>
 </template>

--- a/pages/components/sprint/SprintTaskTable.vue
+++ b/pages/components/sprint/SprintTaskTable.vue
@@ -3,8 +3,8 @@
     <h2 class="text-lg font-semibold text-sky-700 mb-4">📋 Görev ve Hata Durum Tablosu</h2>
 
     <div class="overflow-x-auto rounded-xl border border-blue-100 shadow-sm bg-white">
-      <table class="min-w-full text-sm text-left text-gray-700">
-        <thead class="bg-blue-50 text-gray-600 font-medium">
+      <table class="min-w-full text-sm text-left text-black">
+        <thead class="bg-blue-50 text-black font-medium">
         <tr>
           <th class="px-4 py-3">Tür</th>
           <th class="px-4 py-3">Başlık</th>
@@ -20,20 +20,20 @@
                 {{ item.type === 'hata' ? '🐞 Hata' : '🛠 Görev' }}
               </span>
           </td>
-          <td class="px-4 py-3 font-medium text-gray-800">{{ item.title }}</td>
+          <td class="px-4 py-3 font-medium text-black">{{ item.title }}</td>
           <td class="px-4 py-3">
               <span
                   :class="{
                   'text-green-600 font-semibold': item.status === 'Tamamlandı',
                   'text-yellow-600 font-semibold': item.status === 'Devam',
-                  'text-gray-500 italic': item.status === 'Bekliyor'
+                  'text-black italic': item.status === 'Bekliyor'
                 }"
               >
                 {{ item.status }}
               </span>
           </td>
           <td class="px-4 py-3 capitalize">{{ item.seviye }}</td>
-          <td class="px-4 py-3 text-sm text-gray-500">{{ item.time }}</td>
+          <td class="px-4 py-3 text-sm text-black">{{ item.time }}</td>
         </tr>
         </tbody>
       </table>

--- a/pages/customers/create.vue
+++ b/pages/customers/create.vue
@@ -7,7 +7,7 @@
 
         <!-- Proje Seçimi -->
         <div class="mb-6">
-          <label class="block text-sm font-medium text-gray-700 mb-1">Proje Seç</label>
+          <label class="block text-sm font-medium text-black mb-1">Proje Seç</label>
           <select v-model="selectedProjectId" @change="fetchCustomers" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50">
             <option value="" disabled selected>Bir proje seçin</option>
             <option v-for="project in projects" :key="project.id" :value="project.id">
@@ -21,25 +21,25 @@
           <h2 class="text-2xl font-bold text-sky-700 mb-6">🧾 Yeni Müşteri Kaydı</h2>
           <form class="space-y-6" @submit.prevent="submitCustomer">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Firma Adı</label>
+              <label class="block text-sm font-medium text-black mb-1">Firma Adı</label>
               <input v-model="form.firmaAdi" type="text" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 text-black" required >
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Yetkili Kişi</label>
+              <label class="block text-sm font-medium text-black mb-1">Yetkili Kişi</label>
               <input v-model="form.yetkiliKisi" type="text" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 text-black" required >
             </div>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Email</label>
+                <label class="block text-sm font-medium text-black mb-1">Email</label>
                 <input v-model="form.email" type="email" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 text-black" >
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">Telefon</label>
+                <label class="block text-sm font-medium text-black mb-1">Telefon</label>
                 <input v-model="form.telefon" type="text" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 text-black" >
               </div>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">Notlar</label>
+              <label class="block text-sm font-medium text-black mb-1">Notlar</label>
               <textarea v-model="form.notlar" rows="3" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 resize-none text-black" />
             </div>
             <div class="flex justify-end">
@@ -65,17 +65,17 @@
 
         <!-- Kayıtlı Müşteriler -->
         <div class="mt-12">
-          <h2 class="text-xl font-bold text-gray-700 mb-4">📋 Kayıtlı Müşteriler</h2>
+          <h2 class="text-xl font-bold text-black mb-4">📋 Kayıtlı Müşteriler</h2>
           <div v-if="filteredCustomers.length" class="grid md:grid-cols-2 gap-4">
             <div v-for="customer in filteredCustomers" :key="customer.id" @click="selectCustomer(customer)" class="p-4 rounded-xl bg-white shadow border cursor-pointer hover:border-sky-500">
               <h3 class="text-lg font-semibold text-sky-700">{{ customer.firmaAdi }}</h3>
-              <p class="text-sm text-gray-600">Yetkili: {{ customer.yetkiliKisi }}</p>
-              <p class="text-sm text-gray-500">Email: {{ customer.email }}</p>
-              <p class="text-sm text-gray-500">Telefon: {{ customer.telefon }}</p>
-              <p class="text-sm text-gray-400 mt-2 italic">{{ customer.notlar }}</p>
+              <p class="text-sm text-black">Yetkili: {{ customer.yetkiliKisi }}</p>
+              <p class="text-sm text-black">Email: {{ customer.email }}</p>
+              <p class="text-sm text-black">Telefon: {{ customer.telefon }}</p>
+              <p class="text-sm text-black mt-2 italic">{{ customer.notlar }}</p>
             </div>
           </div>
-          <p v-else class="text-sm text-gray-500 italic mt-4">Henüz müşteri kaydı yok.</p>
+          <p v-else class="text-sm text-black italic mt-4">Henüz müşteri kaydı yok.</p>
         </div>
 
         <!-- Güncelleme Modalı -->
@@ -83,14 +83,14 @@
           <div class="w-full max-w-lg rounded-xl p-6 shadow-xl border border-white/20 backdrop-blur-md" style="background-color: rgba(255, 255, 255, 0.8); box-shadow: 0 0 40px rgba(0, 0, 0, 0.5);">
             <div class="flex justify-between items-center mb-4">
               <h3 class="text-xl font-bold text-sky-700">🔧 Müşteri Güncelle</h3>
-              <button @click="selectedCustomer = null" class="text-gray-400 hover:text-gray-600">✕</button>
+              <button @click="selectedCustomer = null" class="text-black hover:text-black">✕</button>
             </div>
             <form class="space-y-4" @submit.prevent="updateCustomer">
               <input v-model="selectedCustomer.firmaAdi" type="text" class="w-full px-4 py-2 rounded border border-gray-300 text-black" placeholder="Firma Adı" required />
               <input v-model="selectedCustomer.yetkiliKisi" type="text" class="w-full px-4 py-2 rounded border border-gray-300 text-black" placeholder="Yetkili Kişi" required />
               <input v-model="selectedCustomer.email" type="email" class="w-full px-4 py-2 rounded border border-gray-300 text-black" placeholder="Email" />
               <input v-model="selectedCustomer.telefon" type="text" class="w-full px-4 py-2 rounded border border-gray-300 text-black" placeholder="Telefon" />
-              <label class="block text-sm font-medium text-gray-700">Açıklama / Hikaye</label>
+              <label class="block text-sm font-medium text-black">Açıklama / Hikaye</label>
               <textarea v-model="selectedCustomer.notlar" rows="5" class="w-full px-4 py-2 rounded border border-gray-300 resize-none bg-blue-50 text-black"></textarea>
               <div class="flex justify-end">
                 <button type="submit" class="bg-sky-600 text-white px-6 py-2 rounded shadow hover:bg-sky-700">

--- a/pages/customers/marketing.vue
+++ b/pages/customers/marketing.vue
@@ -5,7 +5,7 @@
       <div class="max-w-6xl mx-auto px-4 py-10">
         <!-- Proje Seçimi -->
         <div class="mb-6">
-          <label class="block text-sm font-medium text-gray-700 mb-1">Proje Seç</label>
+          <label class="block text-sm font-medium text-black mb-1">Proje Seç</label>
           <select v-model="selectedProjectId" class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50">
             <option value="">Bir proje seçin</option>
             <option v-for="project in projects" :key="project.id" :value="project.id">{{ project.name }}</option>
@@ -16,7 +16,7 @@
         <div v-if="selectedProjectId">
           <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 mb-10">
             <div v-for="stage in stages" :key="stage.value" class="bg-gray-100 rounded-xl p-3 shadow-inner flex flex-col gap-2">
-              <h3 class="text-sm font-semibold text-gray-700 px-2">{{ stage.label }}</h3>
+              <h3 class="text-sm font-semibold text-black px-2">{{ stage.label }}</h3>
               <draggable
                   :list="filteredCustomersByStage(stage.value)"
                   group="customers"
@@ -34,7 +34,7 @@
                       @click="selectCustomer(element)"
                   >
                     <p class="text-sm font-bold text-sky-700">{{ element.firmaAdi }}</p>
-                    <p class="text-xs text-gray-500">Yetkili: {{ element.yetkiliKisi }}</p>
+                    <p class="text-xs text-black">Yetkili: {{ element.yetkiliKisi }}</p>
                     <p v-if="element.taskStatus" class="text-xs text-sky-600 mt-1">Görev Durumu: {{ element.taskStatus }}</p>
                   </div>
                 </template>
@@ -45,9 +45,9 @@
           <!-- Müşteri Detay Modalı -->
           <div v-if="selectedCustomer" class="fixed inset-0 flex items-center justify-center z-50 bg-black/20 bg-opacity-60">
             <div class="bg-white max-w-xl w-full rounded-xl shadow-lg p-6 relative">
-              <button @click="selectedCustomer = null" class="absolute top-2 right-3 text-gray-400 hover:text-gray-700">&#10005;</button>
+              <button @click="selectedCustomer = null" class="absolute top-2 right-3 text-black hover:text-black">&#10005;</button>
               <h2 class="text-xl font-bold text-sky-700 mb-4">{{ selectedCustomer.firmaAdi }} - Detaylar</h2>
-              <div class="space-y-2 text-sm text-gray-700">
+              <div class="space-y-2 text-sm text-black">
                 <p><strong>Yetkili:</strong> {{ selectedCustomer.yetkiliKisi }}</p>
                 <p><strong>Email:</strong> {{ selectedCustomer.email }}</p>
                 <p><strong>Telefon:</strong> {{ selectedCustomer.telefon }}</p>
@@ -59,8 +59,8 @@
 
           <!-- İstatistikler -->
           <div class="mt-8 bg-white rounded-xl shadow p-6">
-            <h3 class="text-lg font-bold text-gray-700 mb-4 text-center">📊 Genel İstatistikler</h3>
-            <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4 text-sm text-gray-600">
+            <h3 class="text-lg font-bold text-black mb-4 text-center">📊 Genel İstatistikler</h3>
+            <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-4 text-sm text-black">
               <div v-for="stage in stages" :key="stage.value" class="bg-gray-50 border border-gray-200 rounded p-4 shadow-sm text-center">
                 <p class="font-semibold">{{ stage.label }}</p>
                 <p class="text-xl font-bold text-sky-600">{{ filteredCustomersByStage(stage.value).length }}</p>
@@ -69,7 +69,7 @@
           </div>
         </div>
 
-        <p v-else class="text-sm text-gray-500 italic mt-4">Lütfen önce bir proje seçin.</p>
+        <p v-else class="text-sm text-black italic mt-4">Lütfen önce bir proje seçin.</p>
       </div>
     </main>
     <Footer />

--- a/pages/documents/TreeItem.vue
+++ b/pages/documents/TreeItem.vue
@@ -4,7 +4,7 @@
       <!-- Başlık kısmı yönlendirme için router-link oldu -->
       <NuxtLink
           :to="`/documents/writer/${document.id}`"
-          class="text-gray-800 font-medium hover:underline"
+          class="text-black font-medium hover:underline"
       >
         {{ document.title }}
       </NuxtLink>

--- a/pages/documents/list.vue
+++ b/pages/documents/list.vue
@@ -57,12 +57,12 @@
                 @refresh="fetchDocuments"
             />
 
-            <div v-if="rootDocuments.length === 0" class="text-gray-400 text-center mt-8">
+            <div v-if="rootDocuments.length === 0" class="text-black text-center mt-8">
               Bu projede henüz döküman yok. Yeni ana döküman ekleyin.
             </div>
           </div>
 
-          <div v-else class="text-gray-400 text-center mt-12">
+          <div v-else class="text-black text-center mt-12">
             Proje seçiniz. Dökümanlar burada listelenecek.
           </div>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -13,15 +13,15 @@ d="M32 16 C38 10, 54 20, 38 32 Q32 38, 26 32 C10 20, 26 10, 32 16 Z"
       </div>
 
       <h2 class="text-3xl font-bold text-sky-700 mb-2 tracking-tight">EverUp</h2>
-      <p class="text-sm text-gray-500 mb-8 text-center">Projelerini kolayca yönet, sürdürülebilir başarıya ulaş.</p>
+      <p class="text-sm text-black mb-8 text-center">Projelerini kolayca yönet, sürdürülebilir başarıya ulaş.</p>
 
       <form class="w-full space-y-5" @submit.prevent="login">
         <div>
-          <label class="block text-sm font-semibold text-gray-700 mb-1">Eposta</label>
+          <label class="block text-sm font-semibold text-black mb-1">Eposta</label>
           <input v-model="email" type="text" placeholder="eposta gir" class="input-field text-black" required >
         </div>
         <div>
-          <label class="block text-sm font-semibold text-gray-700 mb-1">Şifre</label>
+          <label class="block text-sm font-semibold text-black mb-1">Şifre</label>
           <input v-model="password" type="password" placeholder="••••••••" class="input-field text-black" required >
         </div>
 
@@ -35,7 +35,7 @@ d="M32 16 C38 10, 54 20, 38 32 Q32 38, 26 32 C10 20, 26 10, 32 16 Z"
         <p v-if="error" class="text-red-600 text-sm mt-2 text-center">{{ error }}</p>
       </form>
 
-      <div class="mt-8 text-xs text-gray-400 text-center">
+      <div class="mt-8 text-xs text-black text-center">
         <span>© 2025 EverUp • Sürdürülebilir Proje Asistanı</span>
       </div>
     </div>

--- a/pages/projects/create.vue
+++ b/pages/projects/create.vue
@@ -6,10 +6,10 @@
     <div v-if="showLabelModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
       <div class="bg-white rounded-xl p-6 max-w-md w-full max-h-[90vh] overflow-y-auto">
         <div class="flex justify-between items-center mb-4">
-          <h3 class="text-lg font-bold text-gray-800">
+          <h3 class="text-lg font-bold text-black">
             {{ selectedProject?.name }} - Etiket Yönetimi
           </h3>
-          <button @click="showLabelModal = false" class="text-gray-500 hover:text-gray-700">
+          <button @click="showLabelModal = false" class="text-black hover:text-black">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path d="M6 18L18 6M6 6l12 12" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
@@ -36,9 +36,9 @@
         
         <!-- Etiket Listesi -->
         <div class="space-y-2">
-          <h4 class="font-medium text-gray-700 mb-2">Mevcut Etiketler</h4>
+          <h4 class="font-medium text-black mb-2">Mevcut Etiketler</h4>
           
-          <div v-if="projectLabels.length === 0" class="text-gray-500 text-center py-4">
+          <div v-if="projectLabels.length === 0" class="text-black text-center py-4">
             Bu projede henüz etiket bulunmuyor.
           </div>
           
@@ -77,7 +77,7 @@
 
           <form class="space-y-4" @submit.prevent="submitForm">
             <div>
-              <label class="block text-sm font-medium text-gray-700">Proje Adı</label>
+              <label class="block text-sm font-medium text-black">Proje Adı</label>
               <input
                   v-model="form.title"
                   type="text"
@@ -87,7 +87,7 @@
             </div>
 
             <div>
-              <label class="block text-sm font-medium text-gray-700">Açıklama</label>
+              <label class="block text-sm font-medium text-black">Açıklama</label>
               <textarea
                   v-model="form.description"
                   rows="4"
@@ -97,7 +97,7 @@
             </div>
 
             <div>
-              <label class="block text-sm font-medium text-gray-700">Başlangıç Tarihi</label>
+              <label class="block text-sm font-medium text-black">Başlangıç Tarihi</label>
               <input
                   v-model="form.startDate"
                   type="date"
@@ -127,7 +127,7 @@
             Mevcut Projeler
           </h2>
           
-          <div v-if="projects.length === 0" class="text-gray-500 text-center py-8">
+          <div v-if="projects.length === 0" class="text-black text-center py-8">
             Henüz proje bulunmuyor.
           </div>
           
@@ -138,12 +138,12 @@
               class="border border-gray-200 rounded-lg p-4 hover:shadow-md transition cursor-pointer"
               @click="openLabelModal(project)"
             >
-              <div class="font-medium text-lg text-gray-800">{{ project.name }}</div>
-              <div class="text-sm text-gray-500 mt-1 line-clamp-2">{{ project.description }}</div>
+              <div class="font-medium text-lg text-black">{{ project.name }}</div>
+              <div class="text-sm text-black mt-1 line-clamp-2">{{ project.description }}</div>
               <div class="text-xs text-blue-500 mt-2">
                 Başlangıç: {{ new Date(project.startDate).toLocaleDateString('tr-TR') }}
               </div>
-              <div class="mt-2 text-xs text-gray-500 italic">
+              <div class="mt-2 text-xs text-black italic">
                 Etiket eklemek için tıklayın
               </div>
             </div>

--- a/pages/projects/members.vue
+++ b/pages/projects/members.vue
@@ -14,7 +14,7 @@
 
           <!-- Proje Seçimi -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Proje Seç</label>
+            <label class="block text-sm font-medium text-black mb-1">Proje Seç</label>
             <select v-model="selectedProjectId" class="w-full border p-2 rounded-lg">
               <option value="">-- Proje Seçin --</option>
               <option v-for="project in projects" :key="project.id" :value="project.id">
@@ -30,8 +30,8 @@
                 <div class="flex justify-between items-center">
                   <div>
                     <p class="text-lg font-semibold">{{ member.firstName }} {{ member.lastName }}</p>
-                    <p class="text-sm text-gray-600">{{ member.email }}</p>
-                    <p class="text-sm text-gray-500" v-if="member.role">Rol: {{ roleLabel(member.role) }}</p>
+                    <p class="text-sm text-black">{{ member.email }}</p>
+                    <p class="text-sm text-black" v-if="member.role">Rol: {{ roleLabel(member.role) }}</p>
                   </div>
                   <button class="text-red-500 hover:underline text-sm" @click="removeMember(member.id)">
                     ❌ Kaldır
@@ -39,14 +39,14 @@
                 </div>
               </div>
             </div>
-            <div v-else class="text-gray-500 mt-4">Bu projeye henüz katılımcı eklenmemiş.</div>
+            <div v-else class="text-black mt-4">Bu projeye henüz katılımcı eklenmemiş.</div>
 
             <!-- Katılımcı Ekleme -->
             <form class="bg-gray-50 p-4 rounded-xl border space-y-4 mt-6" @submit.prevent="addMember">
               <h2 class="text-lg font-semibold text-sky-700">Yeni Katılımcı Ekle</h2>
 
               <div>
-                <label class="block text-sm font-medium text-gray-700">Kullanıcı Seç</label>
+                <label class="block text-sm font-medium text-black">Kullanıcı Seç</label>
                 <select v-model="newMember.userId" class="w-full mt-1 p-2 border rounded-lg">
                   <option value="">-- Seçiniz --</option>
                   <option v-for="user in allUsers" :key="user.id" :value="user.id">
@@ -56,7 +56,7 @@
               </div>
 
               <div>
-                <label class="block text-sm font-medium text-gray-700">Projede Rolü</label>
+                <label class="block text-sm font-medium text-black">Projede Rolü</label>
                 <select v-model="newMember.role" class="w-full mt-1 p-2 border rounded-lg">
                   <option value="">-- Rol Seçin --</option>
                   <option v-for="role in roles" :key="role.value" :value="role.value">

--- a/pages/sprint/chart.vue
+++ b/pages/sprint/chart.vue
@@ -10,7 +10,7 @@
 
           <!-- Proje Seç -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Proje Seç</label>
+            <label class="block text-sm font-medium text-black mb-1">Proje Seç</label>
             <select
                 v-model="selectedProjectId"
                 class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 focus:outline-none focus:ring-2 focus:ring-sky-300"
@@ -25,15 +25,15 @@
 
           <!-- İçerik -->
           <div v-if="selectedProjectId">
-            <div v-if="loadingSummary" class="py-6 text-center text-gray-400">Yükleniyor…</div>
+            <div v-if="loadingSummary" class="py-6 text-center text-black">Yükleniyor…</div>
 
             <div v-else-if="selectedSprint" class="space-y-6">
               <div class="space-y-2">
-                <h2 class="text-lg font-semibold text-gray-700">📌 {{ selectedSprint.name }}</h2>
-                <p class="text-sm text-gray-600">
+                <h2 class="text-lg font-semibold text-black">📌 {{ selectedSprint.name }}</h2>
+                <p class="text-sm text-black">
                   Tarih: {{ formatDate(selectedSprint.startDate) }} – {{ formatDate(selectedSprint.endDate) }}
                 </p>
-                <p class="text-sm text-gray-600">
+                <p class="text-sm text-black">
                   Kalan Gün: {{ remainingDays }} gün
                 </p>
               </div>
@@ -54,7 +54,7 @@
               </div>
             </div>
 
-            <div v-else class="py-6 text-center text-gray-500">
+            <div v-else class="py-6 text-center text-black">
               📭 Bu projeye ait aktif bir sprint bulunmamaktadır.
             </div>
           </div>

--- a/pages/sprint/meta.vue
+++ b/pages/sprint/meta.vue
@@ -10,7 +10,7 @@
 
           <!-- Proje Seçimi -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Proje Seç</label>
+            <label class="block text-sm font-medium text-black mb-1">Proje Seç</label>
             <select
                 v-model="selectedProjectId"
                 class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 focus:outline-none focus:ring-2 focus:ring-sky-300"
@@ -25,7 +25,7 @@
 
           <!-- Sprint İçeriği -->
           <div v-if="selectedProjectId">
-            <div v-if="loadingSummary" class="text-gray-400 py-10 text-center">Yükleniyor…</div>
+            <div v-if="loadingSummary" class="text-black py-10 text-center">Yükleniyor…</div>
 
             <div v-else-if="activeSprint" class="space-y-6">
               <SprintMetaInfo :sprint="activeSprint" />
@@ -33,7 +33,7 @@
               <SprintTaskTable :tasks="projectSprintTasks" />
             </div>
 
-            <div v-else class="text-center py-10 text-gray-500">
+            <div v-else class="text-center py-10 text-black">
               📭 Bu projeye ait aktif bir sprint bulunmamaktadır.
             </div>
           </div>

--- a/pages/sprint/task-list.vue
+++ b/pages/sprint/task-list.vue
@@ -9,7 +9,7 @@
 
           <!-- Proje Seç -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">Proje Seç</label>
+            <label class="block text-sm font-medium text-black mb-1">Proje Seç</label>
             <select
                 v-model="selectedProjectId"
                 class="w-full px-4 py-2 rounded-lg border border-gray-300 bg-blue-50 focus:outline-none focus:ring-2 focus:ring-sky-300"
@@ -23,14 +23,14 @@
           <!-- Aktif Sprint ve Görevler -->
           <div v-if="activeSprint">
             <div class="mb-4">
-              <h2 class="text-xl font-semibold text-gray-800">
+              <h2 class="text-xl font-semibold text-black">
                 📋 {{ activeSprint.name }} ({{ activeSprint.startDate }} - {{ activeSprint.endDate }})
               </h2>
             </div>
 
             <!-- Atanmış Görevler -->
             <div>
-              <h3 class="text-lg font-medium text-gray-700 mb-2">Atanmış Görevler</h3>
+              <h3 class="text-lg font-medium text-black mb-2">Atanmış Görevler</h3>
               <ul class="space-y-2">
                 <li
                     v-for="task in assignedTasks"
@@ -46,16 +46,16 @@
                     {{ pending.has(task.id) ? 'Çıkarılıyor…' : 'Sprint\'ten Çıkar' }}
                   </button>
                 </li>
-                <li v-if="!assignedTasks.length && !loadingTasks" class="text-gray-500">
+                <li v-if="!assignedTasks.length && !loadingTasks" class="text-black">
                   Henüz görev atanmadı.
                 </li>
-                <li v-if="loadingTasks" class="text-gray-400">Yükleniyor…</li>
+                <li v-if="loadingTasks" class="text-black">Yükleniyor…</li>
               </ul>
             </div>
 
             <!-- Hazır Görevler -->
             <div class="mt-6">
-              <h3 class="text-lg font-medium text-gray-700 mb-2">Hazır Görevler</h3>
+              <h3 class="text-lg font-medium text-black mb-2">Hazır Görevler</h3>
               <ul class="space-y-2">
                 <li
                     v-for="task in availableTasks"
@@ -71,15 +71,15 @@
                     {{ pending.has(task.id) ? 'Atanıyor…' : 'Ata' }}
                   </button>
                 </li>
-                <li v-if="!availableTasks.length && !loadingTasks" class="text-gray-500">
+                <li v-if="!availableTasks.length && !loadingTasks" class="text-black">
                   Atanabilir görev kalmadı.
                 </li>
-                <li v-if="loadingTasks" class="text-gray-400">Yükleniyor…</li>
+                <li v-if="loadingTasks" class="text-black">Yükleniyor…</li>
               </ul>
             </div>
           </div>
 
-          <div v-else class="py-10 text-center text-gray-400">
+          <div v-else class="py-10 text-center text-black">
             <template v-if="selectedProjectId">
               Aktif sprint yok
             </template>

--- a/pages/tasks/CommentItem.vue
+++ b/pages/tasks/CommentItem.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="ml-4 mt-2">
     <div class="bg-white p-3 rounded-md border border-gray-200 shadow-sm">
-      <p class="text-gray-800">{{ comment.content }}</p>
+      <p class="text-black">{{ comment.content }}</p>
       <div class="flex justify-between items-center mt-2">
-        <p class="text-xs text-gray-500">{{ comment.author }} – {{ formatDate(comment.createdAt) }}</p>
+        <p class="text-xs text-black">{{ comment.author }} – {{ formatDate(comment.createdAt) }}</p>
         <button
             class="text-xs text-blue-500 hover:underline"
             @click="$emit('replyToggle', comment.id)"

--- a/pages/tasks/[id].vue
+++ b/pages/tasks/[id].vue
@@ -11,9 +11,9 @@
 
             <!-- Unique Code + Copy -->
             <div class="mt-2 flex flex-wrap items-center gap-2">
-              <span class="text-xs text-gray-500">Görev Kodu:</span>
+              <span class="text-xs text-black">Görev Kodu:</span>
               <code
-              class="text-xs font-mono bg-gray-100 text-gray-800 px-2 py-1 rounded border border-gray-200">
+              class="text-xs font-mono bg-gray-100 text-black px-2 py-1 rounded border border-gray-200">
                 {{ task.uniqueCode || '—' }}
               </code>
               <button
@@ -31,8 +31,8 @@
               </button>
             </div>
 
-            <p class="mt-2 text-sm text-gray-500">Oluşturulma Tarihi: {{ formatDate(task.createdAt) }}</p>
-            <p class="text-xs text-gray-400 italic">{{ formatDurationSince(task.createdAt) }}</p>
+            <p class="mt-2 text-sm text-black">Oluşturulma Tarihi: {{ formatDate(task.createdAt) }}</p>
+            <p class="text-xs text-black italic">{{ formatDurationSince(task.createdAt) }}</p>
             <p v-if="task.status === 'Ready'" class="mt-1 text-xs text-green-600 font-medium">Başlamaya hazır ✅</p>
           </div>
 
@@ -45,7 +45,7 @@
                 'px-3 py-1 text-sm rounded-lg font-medium border shadow-sm transition-all',
                 task.status === statusOption.value
                   ? statusOption.activeClass
-                  : 'bg-white text-gray-600 border-gray-300 hover:bg-gray-100',
+                  : 'bg-white text-black border-gray-300 hover:bg-gray-100',
                 !canManuallyUpdateStatus ? 'opacity-50 cursor-not-allowed' : ''
               ]"
               @click="updateStatus(statusOption.value)"
@@ -58,28 +58,28 @@
         <!-- Açıklama -->
         <section>
           <h2 class="text-lg font-semibold text-blue-700 mb-2">📄 Görev Açıklaması</h2>
-          <p class="text-gray-700 bg-blue-50 p-4 rounded-md border border-blue-100 whitespace-pre-line">
+          <p class="text-black bg-blue-50 p-4 rounded-md border border-blue-100 whitespace-pre-line">
             {{ task.description }}
           </p>
         </section>
 
         <!-- Bağlı Görevler -->
         <section v-if="task.dependencies?.length">
-          <h2 class="text-lg font-semibold text-gray-700 mb-4">🔗 Bağlı Görevler</h2>
+          <h2 class="text-lg font-semibold text-black mb-4">🔗 Bağlı Görevler</h2>
           <ul class="grid sm:grid-cols-2 gap-4">
             <li
               v-for="dep in task.dependencies"
               :key="dep.id"
               class="flex justify-between items-center p-4 bg-gray-50 border border-gray-200 rounded-lg shadow-sm"
             >
-              <span class="text-gray-800 font-medium">{{ dep.title }}</span>
+              <span class="text-black font-medium">{{ dep.title }}</span>
               <span
                   class="text-xs font-semibold px-2 py-1 rounded"
                   :class="{
                   'bg-green-100 text-green-700': dep.status === 'Completed',
                   'bg-yellow-100 text-yellow-800': dep.status === 'In Progress',
                   'bg-blue-100 text-blue-700': dep.status === 'Ready',
-                  'bg-gray-200 text-gray-600': dep.status === 'Waiting'
+                  'bg-gray-200 text-black': dep.status === 'Waiting'
                 }"
               >
                 {{ dep.status }}
@@ -90,7 +90,7 @@
 
         <!-- Yorumlar -->
         <section>
-          <h2 class="text-lg font-semibold text-gray-700 mb-4">💬 Yorumlar</h2>
+          <h2 class="text-lg font-semibold text-black mb-4">💬 Yorumlar</h2>
 
           <div v-if="commentTree.length" class="space-y-3 max-h-96 overflow-y-auto pr-1">
             <CommentItem
@@ -100,11 +100,11 @@
               @reply-toggle="toggleReply"
             />
           </div>
-          <p v-else class="text-gray-400 italic">Henüz yorum yapılmamış.</p>
+          <p v-else class="text-black italic">Henüz yorum yapılmamış.</p>
 
           <!-- Yorum Yazma -->
           <form class="mt-6 space-y-2" @submit.prevent="submitComment">
-            <div v-if="selectedParentAuthor" class="text-xs text-gray-500 italic">
+            <div v-if="selectedParentAuthor" class="text-xs text-black italic">
               {{ selectedParentAuthor }} adlı yoruma yanıt yazıyorsunuz.
               <button
                 type="button"
@@ -130,7 +130,7 @@
         </section>
       </div>
 
-      <div v-else class="text-center text-gray-500 py-10">
+      <div v-else class="text-center text-black py-10">
         <p>Görev yükleniyor...</p>
       </div>
     </div>
@@ -186,7 +186,7 @@ const statusOptions = [
   { value: 'Ready', label: 'Başlamaya Hazır', activeClass: 'bg-blue-100 text-blue-700 border-blue-300' },
   { value: 'In Progress', label: 'Görev Başlatıldı', activeClass: 'bg-yellow-100 text-yellow-800 border-yellow-300' },
   { value: 'Completed', label: 'Tamamlandı', activeClass: 'bg-green-100 text-green-700 border-green-300' },
-  { value: 'Waiting', label: 'Bekliyor', activeClass: 'bg-gray-100 text-gray-600 border-gray-300' }
+  { value: 'Waiting', label: 'Bekliyor', activeClass: 'bg-gray-100 text-black border-gray-300' }
 ]
 
 const canManuallyUpdateStatus = computed(() => {

--- a/pages/users/update.vue
+++ b/pages/users/update.vue
@@ -10,8 +10,8 @@
           <div v-for="user in users" :key="user.id" class="border p-4 rounded-lg bg-blue-50 shadow-sm space-y-2">
             <div class="flex justify-between items-center">
               <div>
-                <p class="font-semibold text-lg text-gray-800">{{ user.firstName }} {{ user.lastName }}</p>
-                <p class="text-sm text-gray-600">{{ user.email }}</p>
+                <p class="font-semibold text-lg text-black">{{ user.firstName }} {{ user.lastName }}</p>
+                <p class="text-sm text-black">{{ user.email }}</p>
               </div>
 
               <div class="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- replace `text-gray-*` Tailwind classes with `text-black` across all components
- align project styling with global text color conventions

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c71b3669148324a30d3369e4b2ef64