### PR TITLE
Add Pomodoro timer to dashboard

### DIFF
--- a/pages/components/dashboard/DashboardDrawer.vue
+++ b/pages/components/dashboard/DashboardDrawer.vue
@@ -10,6 +10,7 @@
           :notifications="notifications"
         />
         <TaskCreatePanel v-else-if="type === 'taskCreate'" />
+        <PomodoroTimer v-else-if="type === 'pomodoro'" />
       </div>
     </div>
   </transition>
@@ -18,9 +19,10 @@
 <script setup lang="ts">
 import NotificationsPanel from './notifications.vue'
 import TaskCreatePanel from './taskCreate.vue'
+import PomodoroTimer from './pomodoroTimer.vue'
 
 const props = defineProps<{
-  type: 'notifications' | 'taskCreate'
+  type: 'notifications' | 'taskCreate' | 'pomodoro'
   notifications?: any[]
 }>()
 

--- a/pages/components/dashboard/pomodoroTimer.vue
+++ b/pages/components/dashboard/pomodoroTimer.vue
@@ -1,0 +1,246 @@
+<template>
+  <div class="bg-white rounded-xl shadow p-6 flex flex-col h-full">
+    <div class="flex items-start justify-between gap-2">
+      <div>
+        <h2 class="text-xl font-semibold text-gray-800">Pomodoro Zamanlayıcısı</h2>
+        <p class="text-sm text-gray-500">
+          Odak sürenizi yönetmek için Pomodoro yöntemi kullanın.
+        </p>
+      </div>
+      <span
+        class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-sm"
+        :class="currentPhase === 'focus' ? 'bg-red-100 text-red-600' : 'bg-emerald-100 text-emerald-600'"
+      >
+        <span class="h-2 w-2 rounded-full" :class="currentPhase === 'focus' ? 'bg-red-500' : 'bg-emerald-500'"></span>
+        {{ phaseLabel }}
+      </span>
+    </div>
+
+    <div class="mt-4 text-sm text-gray-600" v-if="linkedProjectName">
+      Aktif Proje: <span class="font-medium text-gray-800">{{ linkedProjectName }}</span>
+    </div>
+
+    <div class="mt-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <label class="flex flex-col text-sm font-medium text-gray-700">
+        Odak Süresi (dk)
+        <input
+          v-model.number="workDurationInput"
+          type="number"
+          min="1"
+          class="mt-2 rounded-lg border border-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+      </label>
+      <label class="flex flex-col text-sm font-medium text-gray-700">
+        Mola Süresi (dk)
+        <input
+          v-model.number="breakDurationInput"
+          type="number"
+          min="1"
+          class="mt-2 rounded-lg border border-gray-200 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+      </label>
+    </div>
+
+    <div class="mt-8 text-center">
+      <div class="text-5xl font-bold text-gray-900 tracking-widest">{{ formattedTime }}</div>
+      <div class="mt-4 h-3 bg-gray-200 rounded-full overflow-hidden">
+        <div
+          class="h-full bg-blue-500 transition-all"
+          :style="{ width: progress + '%' }"
+        ></div>
+      </div>
+      <p class="mt-2 text-sm text-gray-500">
+        {{ phaseDescription }}
+      </p>
+    </div>
+
+    <div class="mt-8 flex flex-wrap gap-3 justify-center">
+      <button
+        @click="handleStartPause"
+        class="px-4 py-2 rounded-lg text-white font-medium"
+        :class="isActive ? 'bg-yellow-500 hover:bg-yellow-600' : 'bg-blue-600 hover:bg-blue-700'"
+      >
+        {{ isActive ? 'Duraklat' : 'Başlat' }}
+      </button>
+      <button
+        @click="handleReset"
+        class="px-4 py-2 rounded-lg border border-gray-200 text-gray-700 hover:bg-gray-100 font-medium"
+      >
+        Sıfırla
+      </button>
+      <button
+        @click="handlePhaseToggle"
+        class="px-4 py-2 rounded-lg border border-blue-200 text-blue-600 hover:bg-blue-50 font-medium"
+      >
+        Aşama Değiştir
+      </button>
+    </div>
+
+    <div class="mt-8">
+      <div class="flex items-center justify-between text-sm text-gray-600">
+        <span>Toplam Odak Seansı</span>
+        <span class="font-semibold text-gray-800">{{ completedSessions }}</span>
+      </div>
+      <div class="mt-4">
+        <h3 class="text-sm font-semibold text-gray-700 mb-2">Son Seanslar</h3>
+        <ul class="space-y-2 max-h-40 overflow-y-auto pr-1">
+          <li
+            v-for="session in recentSessions"
+            :key="session.id"
+            class="flex items-center justify-between text-sm text-gray-600"
+          >
+            <div>
+              <p class="font-medium text-gray-800">{{ formatSessionDate(session.completedAt) }}</p>
+              <p class="text-xs text-gray-500">
+                Odak: {{ session.focusDuration }} dk · Mola: {{ session.breakDuration }} dk
+              </p>
+            </div>
+            <span v-if="session.projectName" class="text-xs bg-gray-100 px-2 py-1 rounded-full text-gray-600">
+              {{ session.projectName }}
+            </span>
+          </li>
+          <li v-if="!recentSessions.length" class="text-sm text-gray-400 text-center py-2">
+            Henüz seans kaydı bulunmuyor.
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { storeToRefs } from 'pinia'
+import { usePomodoroStore } from '@/stores/pomodoroStore'
+import { useProjectStore } from '@/stores/projectStore'
+
+const pomodoroStore = usePomodoroStore()
+const projectStore = useProjectStore()
+
+const {
+  workDuration,
+  breakDuration,
+  remainingSeconds,
+  currentPhase,
+  isActive,
+  completedSessions,
+  sessionHistory,
+  linkedProjectName,
+  linkedProjectId
+} = storeToRefs(pomodoroStore)
+
+const workDurationInput = ref(workDuration.value)
+const breakDurationInput = ref(breakDuration.value)
+const isHydrated = ref(false)
+
+const formattedTime = computed(() => {
+  const minutes = Math.floor(remainingSeconds.value / 60)
+  const seconds = remainingSeconds.value % 60
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
+})
+
+const phaseLabel = computed(() => (currentPhase.value === 'focus' ? 'Odak' : 'Mola'))
+const phaseDescription = computed(() =>
+  currentPhase.value === 'focus'
+    ? 'Şimdi odaklanma zamanı!'
+    : 'Kısa bir mola verin ve rahatlayın.'
+)
+
+const progress = computed(() => {
+  const total = currentPhase.value === 'focus'
+    ? workDuration.value * 60
+    : breakDuration.value * 60
+  if (total === 0) {
+    return 0
+  }
+  const elapsed = total - remainingSeconds.value
+  return Math.min(100, Math.max(0, (elapsed / total) * 100))
+})
+
+const recentSessions = computed(() => sessionHistory.value.slice(0, 5))
+
+const handleStartPause = () => {
+  if (isActive.value) {
+    pomodoroStore.pauseTimer()
+  } else {
+    pomodoroStore.startTimer()
+  }
+}
+
+const handleReset = () => {
+  pomodoroStore.resetTimer()
+}
+
+const handlePhaseToggle = () => {
+  pomodoroStore.togglePhase(true)
+}
+
+const formatSessionDate = (dateIso: string) => {
+  if (!dateIso) {
+    return ''
+  }
+  try {
+    return new Intl.DateTimeFormat('tr-TR', {
+      hour: '2-digit',
+      minute: '2-digit',
+      day: '2-digit',
+      month: 'short'
+    }).format(new Date(dateIso))
+  } catch (error) {
+    console.warn('Tarih formatlanırken hata oluştu:', error)
+    return dateIso
+  }
+}
+
+watch(workDurationInput, (value) => {
+  if (Number.isFinite(value)) {
+    pomodoroStore.setWorkDuration(value)
+  }
+})
+
+watch(breakDurationInput, (value) => {
+  if (Number.isFinite(value)) {
+    pomodoroStore.setBreakDuration(value)
+  }
+})
+
+watch(workDuration, (value) => {
+  if (workDurationInput.value !== value) {
+    workDurationInput.value = value
+  }
+})
+
+watch(breakDuration, (value) => {
+  if (breakDurationInput.value !== value) {
+    breakDurationInput.value = value
+  }
+})
+
+watch(
+  () => [projectStore.selectedProjectId, projectStore.selectedProjectName] as const,
+  ([projectId, projectName]) => {
+    if (!isHydrated.value) {
+      return
+    }
+
+    if (projectId !== null) {
+      pomodoroStore.linkProject(projectId, projectName ?? null)
+    } else if (linkedProjectId.value !== null) {
+      pomodoroStore.linkProject(null, null)
+    }
+  }
+)
+
+onMounted(() => {
+  pomodoroStore.initializeFromStorage()
+  isHydrated.value = true
+
+  if (projectStore.selectedProjectId !== null) {
+    pomodoroStore.linkProject(projectStore.selectedProjectId, projectStore.selectedProjectName)
+  }
+})
+
+onBeforeUnmount(() => {
+  pomodoroStore.pauseTimer()
+})
+</script>

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -8,17 +8,21 @@
         <button @click="openDrawer('taskCreate')" class="px-4 py-2 rounded bg-green-500 text-white w-full text-left">
           Görev Oluştur
         </button>
+        <button @click="openDrawer('pomodoro')" class="mt-2 px-4 py-2 rounded bg-red-500 text-white w-full text-left">
+          Pomodoro Sayacı
+        </button>
       </template>
     </Navbar>
 
-    <div class="md:hidden p-4">
+    <div class="md:hidden p-4 space-y-4">
       <TaskListPanel />
+      <PomodoroTimer />
     </div>
 
-    <!-- Masaüstü görünüm: 1:3:2 oranında grid -->
+    <!-- Masaüstü görünüm: 1:3:2:2 oranında grid -->
     <div
         class="hidden md:grid px-8 gap-6 py-6"
-        style="height: calc(100vh - 4rem); grid-template-columns: 1fr 3fr 2fr;"
+        style="height: calc(100vh - 4rem); grid-template-columns: 1fr 3fr 2fr 2fr;"
     >
       <!-- Bildirimler + Yorumlar -->
       <div class="bg-white rounded-xl shadow h-full flex flex-col overflow-hidden">
@@ -39,6 +43,9 @@
 
       <!-- Görev Oluştur -->
       <TaskCreatePanel class="flex flex-col h-full"/>
+
+      <!-- Pomodoro Zamanlayıcı -->
+      <PomodoroTimer class="flex flex-col h-full" />
     </div>
 
     <DashboardDrawer
@@ -56,15 +63,16 @@ import NotificationsPanel from './components/dashboard/notifications.vue'
 import TaskListPanel from './components/dashboard/taskList.vue'
 import TaskCreatePanel from './components/dashboard/taskCreate.vue'
 import CommentListPanel from './components/dashboard/commentList.vue'
+import PomodoroTimer from './components/dashboard/pomodoroTimer.vue'
 import Navbar from './components/bar/Navbar.vue'
 import DashboardDrawer from './components/dashboard/DashboardDrawer.vue'
 import { useFetch } from '#app'
 
 const comments = ref([])
 const notifications = ref([])
-const drawerType = ref<null | 'notifications' | 'taskCreate'>(null)
+const drawerType = ref<null | 'notifications' | 'taskCreate' | 'pomodoro'>(null)
 
-const openDrawer = (type: 'notifications' | 'taskCreate') => {
+const openDrawer = (type: 'notifications' | 'taskCreate' | 'pomodoro') => {
   drawerType.value = type
 }
 

--- a/stores/pomodoroStore.ts
+++ b/stores/pomodoroStore.ts
@@ -1,0 +1,221 @@
+// stores/pomodoroStore.ts
+import { defineStore } from 'pinia'
+
+export type PomodoroPhase = 'focus' | 'break'
+
+export interface PomodoroSession {
+    id: string
+    startedAt: string
+    completedAt: string
+    focusDuration: number
+    breakDuration: number
+    projectId: number | null
+    projectName: string | null
+    taskId: number | null
+}
+
+interface PomodoroSettings {
+    workDuration: number
+    breakDuration: number
+    linkedProjectId: number | null
+    linkedProjectName: string | null
+    linkedTaskId: number | null
+}
+
+const SESSION_STORAGE_KEY = 'everup:pomodoro:sessions'
+const SETTINGS_STORAGE_KEY = 'everup:pomodoro:settings'
+
+export const usePomodoroStore = defineStore('pomodoro', {
+    state: () => ({
+        workDuration: 25,
+        breakDuration: 5,
+        currentPhase: 'focus' as PomodoroPhase,
+        remainingSeconds: 25 * 60,
+        isActive: false,
+        completedSessions: 0,
+        sessionHistory: [] as PomodoroSession[],
+        timerId: null as ReturnType<typeof setInterval> | null,
+        cycleStartedAt: null as string | null,
+        linkedProjectId: null as number | null,
+        linkedProjectName: null as string | null,
+        linkedTaskId: null as number | null
+    }),
+    actions: {
+        initializeFromStorage() {
+            if (!process.client) {
+                return
+            }
+
+            const storedSessions = window.localStorage.getItem(SESSION_STORAGE_KEY)
+            if (storedSessions) {
+                try {
+                    const parsed: PomodoroSession[] = JSON.parse(storedSessions)
+                    this.sessionHistory = parsed
+                    this.completedSessions = parsed.length
+                } catch (error) {
+                    console.warn('Pomodoro oturumları yüklenirken hata oluştu:', error)
+                }
+            }
+
+            const storedSettings = window.localStorage.getItem(SETTINGS_STORAGE_KEY)
+            if (storedSettings) {
+                try {
+                    const parsed: PomodoroSettings = JSON.parse(storedSettings)
+                    this.workDuration = parsed.workDuration
+                    this.breakDuration = parsed.breakDuration
+                    this.linkedProjectId = parsed.linkedProjectId
+                    this.linkedProjectName = parsed.linkedProjectName
+                    this.linkedTaskId = parsed.linkedTaskId
+                    if (this.currentPhase === 'focus') {
+                        this.remainingSeconds = this.workDuration * 60
+                    } else {
+                        this.remainingSeconds = this.breakDuration * 60
+                    }
+                } catch (error) {
+                    console.warn('Pomodoro ayarları yüklenirken hata oluştu:', error)
+                }
+            }
+        },
+        setWorkDuration(minutes: number) {
+            const sanitized = Math.max(1, Math.round(minutes))
+            this.workDuration = sanitized
+            if (this.currentPhase === 'focus' && !this.isActive) {
+                this.remainingSeconds = sanitized * 60
+            }
+            this.persistSettings()
+        },
+        setBreakDuration(minutes: number) {
+            const sanitized = Math.max(1, Math.round(minutes))
+            this.breakDuration = sanitized
+            if (this.currentPhase === 'break' && !this.isActive) {
+                this.remainingSeconds = sanitized * 60
+            }
+            this.persistSettings()
+        },
+        linkProject(projectId: number | null, projectName: string | null) {
+            this.linkedProjectId = projectId
+            this.linkedProjectName = projectName
+            this.persistSettings()
+        },
+        linkTask(taskId: number | null) {
+            this.linkedTaskId = taskId
+            this.persistSettings()
+        },
+        startTimer() {
+            if (this.isActive || !process.client) {
+                return
+            }
+
+            if (!this.cycleStartedAt) {
+                this.cycleStartedAt = new Date().toISOString()
+            }
+
+            this.isActive = true
+            this.timerId = setInterval(() => {
+                this.tick()
+            }, 1000)
+        },
+        pauseTimer() {
+            this.isActive = false
+            this.clearTimerInterval()
+        },
+        resetTimer() {
+            this.pauseTimer()
+            this.currentPhase = 'focus'
+            this.remainingSeconds = this.workDuration * 60
+            this.cycleStartedAt = null
+        },
+        tick() {
+            if (!this.isActive) {
+                return
+            }
+
+            if (this.remainingSeconds > 0) {
+                this.remainingSeconds -= 1
+                return
+            }
+
+            this.completePhase()
+        },
+        completePhase() {
+            this.togglePhase(false)
+        },
+        togglePhase(manual = false) {
+            if (this.currentPhase === 'focus') {
+                if (!manual) {
+                    this.completedSessions += 1
+                    this.recordSession()
+                }
+                this.cycleStartedAt = null
+                this.currentPhase = 'break'
+                this.remainingSeconds = this.breakDuration * 60
+                if (manual) {
+                    this.pauseTimer()
+                }
+            } else {
+                this.currentPhase = 'focus'
+                this.remainingSeconds = this.workDuration * 60
+                if (manual) {
+                    this.pauseTimer()
+                    this.cycleStartedAt = null
+                } else if (this.isActive) {
+                    this.cycleStartedAt = new Date().toISOString()
+                } else {
+                    this.cycleStartedAt = null
+                }
+            }
+        },
+        recordSession() {
+            const completedAt = new Date().toISOString()
+            const startedAt = this.cycleStartedAt || completedAt
+            const session: PomodoroSession = {
+                id: completedAt,
+                startedAt,
+                completedAt,
+                focusDuration: this.workDuration,
+                breakDuration: this.breakDuration,
+                projectId: this.linkedProjectId,
+                projectName: this.linkedProjectName,
+                taskId: this.linkedTaskId
+            }
+            this.sessionHistory = [session, ...this.sessionHistory]
+            this.persistSessions()
+        },
+        clearTimerInterval() {
+            if (this.timerId) {
+                clearInterval(this.timerId)
+                this.timerId = null
+            }
+        },
+        persistSessions() {
+            if (!process.client) {
+                return
+            }
+
+            try {
+                window.localStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(this.sessionHistory))
+            } catch (error) {
+                console.warn('Pomodoro oturumları kaydedilirken hata oluştu:', error)
+            }
+        },
+        persistSettings() {
+            if (!process.client) {
+                return
+            }
+
+            const settings: PomodoroSettings = {
+                workDuration: this.workDuration,
+                breakDuration: this.breakDuration,
+                linkedProjectId: this.linkedProjectId,
+                linkedProjectName: this.linkedProjectName,
+                linkedTaskId: this.linkedTaskId
+            }
+
+            try {
+                window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(settings))
+            } catch (error) {
+                console.warn('Pomodoro ayarları kaydedilirken hata oluştu:', error)
+            }
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- add a dedicated Pinia store to manage pomodoro configuration, playback, and persistence
- implement a dashboard pomodoro timer component with controls, progress, and session history
- surface the timer in the dashboard layout and mobile drawer alongside existing panels

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc59c1c9e88324b4407c7940ddbba8