### PR TITLE
feat: add voice room component

### DIFF
--- a/components/VoiceRoom.vue
+++ b/components/VoiceRoom.vue
@@ -1,0 +1,396 @@
+<template>
+  <section class="voice-room">
+    <header class="voice-room__header">
+      <button
+        class="voice-room__join"
+        :disabled="isJoining || joined"
+        @click="joinRoom"
+      >
+        {{ joined ? 'Bağlandın' : 'Odaya Katıl' }}
+      </button>
+      <button
+        v-if="localStream"
+        class="voice-room__mute"
+        type="button"
+        @click="toggleMute"
+      >
+        {{ voiceStore.localMuted ? 'Sesi Aç' : 'Sesi Kapat' }}
+      </button>
+    </header>
+
+    <p v-if="errorMessage" class="voice-room__error">
+      {{ errorMessage }}
+    </p>
+
+    <div v-if="localStream" class="voice-room__local">
+      <video ref="localVideo" autoplay playsinline muted class="voice-room__video" />
+      <span class="voice-room__label">{{ voiceStore.username || 'Sen' }}</span>
+    </div>
+
+    <div class="voice-room__remote-grid">
+      <article
+        v-for="participant in remoteParticipants"
+        :key="participant.id"
+        class="voice-room__remote-item"
+        :data-muted="participant.muted"
+      >
+        <video
+          autoplay
+          playsinline
+          class="voice-room__video"
+          :data-muted="participant.muted"
+          :ref="(el) => setRemoteVideoRef(participant.id, el)"
+        />
+        <footer class="voice-room__label">
+          <span>{{ participant.username }}</span>
+          <span v-if="participant.muted" aria-label="katılımcı sessizde">🔇</span>
+        </footer>
+      </article>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { useRuntimeConfig } from '#imports'
+import { useVoiceStore } from '~/stores/voiceStore'
+import { createVoiceSocket, type VoiceSocket } from '~/composables/voice/socket'
+import {
+  createRecvTransport,
+  createSendTransport,
+  type RecvTransport,
+  type SendTransport,
+  type TransportOptions,
+} from '~/composables/voice/webrtc'
+
+type ParticipantPayload = {
+  id: string
+  username: string
+  muted?: boolean
+}
+
+type ParticipantListResponse = Array<ParticipantPayload>
+
+type JoinResponse = {
+  id: string
+}
+
+interface JoinRoomProps {
+  roomId: string
+  username: string
+  signalingUrl?: string
+}
+
+const props = defineProps<JoinRoomProps>()
+
+const voiceStore = useVoiceStore()
+const localVideo = ref<HTMLVideoElement | null>(null)
+const localStream = ref<MediaStream | null>(null)
+const remoteVideoRefs = ref<Record<string, HTMLVideoElement | null>>({})
+const socket = ref<VoiceSocket | null>(null)
+const sendTransport = ref<SendTransport | null>(null)
+const recvTransports = ref<Record<string, RecvTransport>>({})
+const detachSocketEvents = ref<(() => void) | null>(null)
+const errorMessage = ref<string | null>(null)
+const isJoining = ref(false)
+
+const joined = computed(() => voiceStore.joined)
+const remoteParticipants = computed(() => voiceStore.remoteParticipants)
+
+const runtimeConfig = useRuntimeConfig()
+const resolveSignalingUrl = () =>
+  props.signalingUrl || runtimeConfig.public?.voiceSignalingUrl || 'ws://localhost:4000/voice'
+
+const attachLocalStream = () => {
+  if (!process.client) return
+  if (!localVideo.value || !localStream.value) return
+  if ('srcObject' in localVideo.value) {
+    localVideo.value.srcObject = localStream.value
+  }
+}
+
+const attachRemoteStream = (participantId: string) => {
+  if (!process.client) return
+  const video = remoteVideoRefs.value[participantId]
+  const participant = voiceStore.participants[participantId]
+  if (video && participant?.stream) {
+    video.srcObject = participant.stream
+  }
+}
+
+const setRemoteVideoRef = (participantId: string, el: HTMLVideoElement | null) => {
+  if (!el) {
+    delete remoteVideoRefs.value[participantId]
+    return
+  }
+  remoteVideoRefs.value[participantId] = el
+  if (el) {
+    attachRemoteStream(participantId)
+  }
+}
+
+const setupRecvForParticipant = async (payload: ParticipantPayload) => {
+  if (!socket.value || recvTransports.value[payload.id]) return
+  try {
+    const transportOptions = (await socket.value.request('create-transport', {
+      direction: 'recv',
+      participantId: payload.id,
+    })) as TransportOptions
+    const transport = await createRecvTransport(socket.value, {
+      ...transportOptions,
+      participantId: payload.id,
+    })
+    recvTransports.value[payload.id] = transport
+    voiceStore.setParticipantStream(payload.id, transport.stream)
+    attachRemoteStream(payload.id)
+  } catch (error) {
+    console.error('[voice] failed to create recv transport', error)
+  }
+}
+
+const registerSocketEvents = (voiceSocket: VoiceSocket) => {
+  const handleParticipantJoined = async (payload: ParticipantPayload) => {
+    voiceStore.upsertParticipant(payload)
+    await setupRecvForParticipant(payload)
+  }
+
+  const handleParticipantLeft = (payload: { id: string }) => {
+    const transport = recvTransports.value[payload.id]
+    transport?.close()
+    delete recvTransports.value[payload.id]
+    voiceStore.removeParticipant(payload.id)
+  }
+
+  const handleParticipantMuted = (payload: { id: string; muted: boolean }) => {
+    voiceStore.setParticipantMuted(payload.id, payload.muted)
+  }
+
+  const handleParticipantUpdated = (payload: ParticipantPayload) => {
+    voiceStore.upsertParticipant(payload)
+  }
+
+  voiceSocket.on('participant-joined', handleParticipantJoined)
+  voiceSocket.on('participant-left', handleParticipantLeft)
+  voiceSocket.on('participant-muted', handleParticipantMuted)
+  voiceSocket.on('participant-updated', handleParticipantUpdated)
+
+  return () => {
+    voiceSocket.off('participant-joined', handleParticipantJoined)
+    voiceSocket.off('participant-left', handleParticipantLeft)
+    voiceSocket.off('participant-muted', handleParticipantMuted)
+    voiceSocket.off('participant-updated', handleParticipantUpdated)
+  }
+}
+
+const joinRoom = async () => {
+  if (!process.client || joined.value) return
+  if (!props.roomId || !props.username) {
+    errorMessage.value = 'Katılım için oda ve kullanıcı bilgileri gerekli.'
+    return
+  }
+
+  isJoining.value = true
+  errorMessage.value = null
+
+  try {
+    voiceStore.setIdentity({ roomId: props.roomId, username: props.username })
+
+    const voiceSocket = createVoiceSocket(resolveSignalingUrl())
+    socket.value = voiceSocket
+    await voiceSocket.connect()
+
+    await voiceSocket.request<JoinResponse>('join-room', {
+      roomId: props.roomId,
+      username: props.username,
+    })
+
+    const mediaStream = await navigator.mediaDevices.getUserMedia({
+      audio: true,
+      video: true,
+    })
+    localStream.value = mediaStream
+    voiceStore.setLocalStream(mediaStream)
+    attachLocalStream()
+
+    const sendTransportOptions = (await voiceSocket.request('create-transport', {
+      direction: 'send',
+    })) as TransportOptions
+    sendTransport.value = await createSendTransport(voiceSocket, sendTransportOptions)
+    await sendTransport.value.publish(mediaStream)
+
+    const participants = (await voiceSocket.request('participants')) as ParticipantListResponse
+    await Promise.all(
+      participants.map(async (participant) => {
+        voiceStore.upsertParticipant(participant)
+        await setupRecvForParticipant(participant)
+      }),
+    )
+
+    detachSocketEvents.value = registerSocketEvents(voiceSocket)
+    voiceStore.markJoined(true)
+  } catch (error) {
+    console.error('[voice] failed to join room', error)
+    errorMessage.value =
+      error instanceof Error ? error.message : 'Odaya katılırken bir hata oluştu.'
+    await cleanup()
+    voiceStore.reset()
+    voiceStore.setIdentity({ roomId: props.roomId, username: props.username })
+  } finally {
+    isJoining.value = false
+  }
+}
+
+const toggleMute = async () => {
+  if (!localStream.value) return
+  const shouldMute = !voiceStore.localMuted
+  localStream.value.getAudioTracks().forEach((track) => {
+    track.enabled = !shouldMute
+  })
+  if (shouldMute) {
+    sendTransport.value?.pause(localStream.value)
+  } else {
+    sendTransport.value?.resume(localStream.value)
+  }
+  voiceStore.setLocalMuted(shouldMute)
+  socket.value?.emit('set-mute', {
+    muted: shouldMute,
+  })
+}
+
+const cleanup = async () => {
+  sendTransport.value?.close()
+  sendTransport.value = null
+
+  Object.values(recvTransports.value).forEach((transport) => transport.close())
+  recvTransports.value = {}
+
+  if (localStream.value) {
+    localStream.value.getTracks().forEach((track) => track.stop())
+  }
+  localStream.value = null
+  voiceStore.setLocalStream(null)
+
+  detachSocketEvents.value?.()
+  detachSocketEvents.value = null
+
+  if (socket.value?.isConnected()) {
+    socket.value.emit('leave-room', {
+      roomId: voiceStore.roomId,
+    })
+  }
+  socket.value?.disconnect()
+  socket.value = null
+
+  Object.keys(voiceStore.participants).forEach((participantId) => {
+    voiceStore.removeParticipant(participantId)
+  })
+  voiceStore.setLocalMuted(false)
+  voiceStore.markJoined(false)
+}
+
+onMounted(() => {
+  if (!process.client) return
+  if (props.roomId && props.username) {
+    voiceStore.setIdentity({ roomId: props.roomId, username: props.username })
+  }
+  if (voiceStore.localStream) {
+    localStream.value = voiceStore.localStream
+    attachLocalStream()
+  }
+})
+
+onBeforeUnmount(async () => {
+  await cleanup()
+  voiceStore.reset()
+})
+
+watch(
+  () => voiceStore.remoteParticipants,
+  (participants) => {
+    participants.forEach((participant) => attachRemoteStream(participant.id))
+  },
+  { deep: true },
+)
+</script>
+
+<style scoped>
+.voice-room {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 1rem;
+  color: #f8fafc;
+}
+
+.voice-room__header {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.voice-room__join,
+.voice-room__mute {
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  border: none;
+  cursor: pointer;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+  transition: filter 0.2s ease;
+}
+
+.voice-room__join[disabled] {
+  cursor: not-allowed;
+  filter: grayscale(1);
+}
+
+.voice-room__mute {
+  background: #0f172a;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.voice-room__error {
+  color: #f87171;
+  font-weight: 500;
+}
+
+.voice-room__local,
+.voice-room__remote-item {
+  position: relative;
+  border-radius: 0.75rem;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.voice-room__video {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: #0f172a;
+  object-fit: cover;
+}
+
+.voice-room__label {
+  position: absolute;
+  left: 0.75rem;
+  bottom: 0.75rem;
+  background: rgba(15, 23, 42, 0.85);
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+}
+
+.voice-room__remote-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.voice-room__remote-item[data-muted='true'] .voice-room__video {
+  filter: grayscale(1);
+}
+</style>

--- a/composables/voice/socket.ts
+++ b/composables/voice/socket.ts
@@ -1,0 +1,142 @@
+/* eslint-disable no-console */
+export interface VoiceSocketEvent<T = unknown> {
+  event: string
+  data?: T
+  id?: string
+}
+
+export interface VoiceSocket {
+  connect: () => Promise<void>
+  disconnect: () => void
+  request: <T = unknown>(event: string, payload?: unknown) => Promise<T>
+  emit: (event: string, payload?: unknown) => void
+  on: (event: string, handler: (payload: any) => void) => void
+  off: (event: string, handler: (payload: any) => void) => void
+  isConnected: () => boolean
+}
+
+interface PendingRequest {
+  resolve: (payload: any) => void
+  reject: (error: any) => void
+  timeout: ReturnType<typeof setTimeout>
+}
+
+const ACK_TIMEOUT = 10_000
+
+export const createVoiceSocket = (url: string): VoiceSocket => {
+  if (typeof window === 'undefined') {
+    throw new Error('Voice socket can only be created in the browser context')
+  }
+
+  let socket: WebSocket | null = null
+  const listeners = new Map<string, Set<(payload: any) => void>>()
+  const pending = new Map<string, PendingRequest>()
+  let connected = false
+
+  const notify = (event: string, payload: any) => {
+    const handlers = listeners.get(event)
+    handlers?.forEach((handler) => handler(payload))
+  }
+
+  const connect = () =>
+    new Promise<void>((resolve, reject) => {
+      socket = new WebSocket(url)
+
+      socket.addEventListener('open', () => {
+        connected = true
+        resolve()
+      })
+
+      socket.addEventListener('error', (error) => {
+        console.error('[voice] socket error', error)
+        reject(error)
+      })
+
+      socket.addEventListener('close', () => {
+        connected = false
+        pending.forEach(({ reject, timeout }) => {
+          clearTimeout(timeout)
+          reject(new Error('Socket connection closed'))
+        })
+        pending.clear()
+        listeners.clear()
+      })
+
+      socket.addEventListener('message', (event) => {
+        try {
+          const payload: VoiceSocketEvent & { replyTo?: string; error?: any } = JSON.parse(event.data)
+          if (payload.replyTo) {
+            const pendingRequest = pending.get(payload.replyTo)
+            if (pendingRequest) {
+              clearTimeout(pendingRequest.timeout)
+              pendingRequest[payload.error ? 'reject' : 'resolve'](payload.error ?? payload.data)
+              pending.delete(payload.replyTo)
+            }
+            return
+          }
+          notify(payload.event, payload.data)
+        } catch (error) {
+          console.warn('[voice] failed to parse socket message', error)
+        }
+      })
+    })
+
+  const disconnect = () => {
+    socket?.close()
+    socket = null
+    connected = false
+  }
+
+  const emit = (event: string, data?: any) => {
+    if (!socket || socket.readyState !== WebSocket.OPEN) return
+    const payload: VoiceSocketEvent = { event, data }
+    socket.send(JSON.stringify(payload))
+  }
+
+  const request = <T = unknown>(event: string, data?: any) => {
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error('Socket is not connected'))
+    }
+    const id =
+      typeof crypto !== 'undefined' && 'randomUUID' in crypto
+        ? crypto.randomUUID()
+        : Math.random().toString(36).slice(2)
+    const payload: VoiceSocketEvent = { id, event, data }
+    socket.send(JSON.stringify(payload))
+
+    return new Promise<T>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pending.delete(id)
+        reject(new Error(`Request timeout for event ${event}`))
+      }, ACK_TIMEOUT)
+
+      pending.set(id, { resolve, reject, timeout })
+    })
+  }
+
+  const on = (event: string, handler: (payload: any) => void) => {
+    const handlers = listeners.get(event) ?? new Set<(payload: any) => void>()
+    handlers.add(handler)
+    listeners.set(event, handlers)
+  }
+
+  const off = (event: string, handler: (payload: any) => void) => {
+    const handlers = listeners.get(event)
+    handlers?.delete(handler)
+    if (handlers && handlers.size === 0) {
+      listeners.delete(event)
+    }
+  }
+
+  const isConnected = () => connected
+
+  return {
+    connect,
+    disconnect,
+    request,
+    emit,
+    on,
+    off,
+    isConnected,
+  }
+}

--- a/composables/voice/webrtc.ts
+++ b/composables/voice/webrtc.ts
@@ -1,0 +1,95 @@
+import type { VoiceSocket } from './socket'
+
+export interface TransportOptions {
+  id: string
+  iceParameters?: RTCConfiguration
+  dtlsParameters?: unknown
+  kind?: 'audio' | 'video'
+}
+
+export interface SendTransport {
+  id: string
+  publish: (stream: MediaStream) => Promise<void>
+  pause: (stream: MediaStream) => void
+  resume: (stream: MediaStream) => void
+  close: () => void
+}
+
+export interface RecvTransport {
+  id: string
+  stream: MediaStream
+  close: () => void
+}
+
+export const createSendTransport = async (
+  socket: VoiceSocket,
+  options: TransportOptions,
+): Promise<SendTransport> => {
+  let closed = false
+
+  const publish = async (stream: MediaStream) => {
+    if (closed) return
+    const payload = {
+      transportId: options.id,
+      kind: options.kind ?? 'audio',
+      paused: false,
+    }
+    await socket.request('transport-produce', payload)
+    stream.getTracks().forEach((track) => {
+      track.enabled = true
+    })
+  }
+
+  const pause = (stream: MediaStream) => {
+    if (closed) return
+    stream.getAudioTracks().forEach((track) => {
+      track.enabled = false
+    })
+    stream.getVideoTracks().forEach((track) => {
+      track.enabled = false
+    })
+    socket.emit('transport-pause', { transportId: options.id })
+  }
+
+  const resume = (stream: MediaStream) => {
+    if (closed) return
+    stream.getTracks().forEach((track) => {
+      track.enabled = true
+    })
+    socket.emit('transport-resume', { transportId: options.id })
+  }
+
+  const close = () => {
+    if (closed) return
+    closed = true
+    socket.emit('transport-close', { transportId: options.id })
+  }
+
+  return {
+    id: options.id,
+    publish,
+    pause,
+    resume,
+    close,
+  }
+}
+
+export const createRecvTransport = async (
+  socket: VoiceSocket,
+  options: TransportOptions & { participantId: string },
+): Promise<RecvTransport> => {
+  const stream = new MediaStream()
+  await socket.request('transport-consume', {
+    transportId: options.id,
+    participantId: options.participantId,
+  })
+
+  return {
+    id: options.id,
+    stream,
+    close: () => {
+      stream.getTracks().forEach((track) => track.stop())
+      socket.emit('transport-close', { transportId: options.id })
+    },
+  }
+}

--- a/stores/voiceStore.ts
+++ b/stores/voiceStore.ts
@@ -1,0 +1,97 @@
+import { defineStore } from 'pinia'
+
+export interface VoiceParticipant {
+  id: string
+  username: string
+  stream: MediaStream | null
+  muted: boolean
+}
+
+interface IdentityPayload {
+  roomId: string
+  username: string
+}
+
+interface ParticipantUpdatePayload {
+  id: string
+  username: string
+  muted?: boolean
+  stream?: MediaStream | null
+}
+
+export const useVoiceStore = defineStore('voice', {
+  state: () => ({
+    identity: { roomId: '', username: '' } as IdentityPayload,
+    localStream: null as MediaStream | null,
+    localMuted: false,
+    participants: {} as Record<string, VoiceParticipant>,
+    joined: false,
+  }),
+  getters: {
+    roomId: (state) => state.identity.roomId,
+    username: (state) => state.identity.username,
+    remoteParticipants: (state) => Object.values(state.participants),
+  },
+  actions: {
+    setIdentity(payload: IdentityPayload) {
+      this.identity = payload
+    },
+    setLocalStream(stream: MediaStream | null) {
+      this.localStream = stream
+    },
+    setLocalMuted(muted: boolean) {
+      this.localMuted = muted
+    },
+    markJoined(joined: boolean) {
+      this.joined = joined
+    },
+    upsertParticipant(payload: ParticipantUpdatePayload) {
+      const existing = this.participants[payload.id]
+      if (existing) {
+        this.participants[payload.id] = {
+          ...existing,
+          username: payload.username ?? existing.username,
+          stream: payload.stream ?? existing.stream,
+          muted: payload.muted ?? existing.muted,
+        }
+      } else {
+        this.participants[payload.id] = {
+          id: payload.id,
+          username: payload.username,
+          stream: payload.stream ?? null,
+          muted: payload.muted ?? false,
+        }
+      }
+    },
+    removeParticipant(participantId: string) {
+      delete this.participants[participantId]
+    },
+    setParticipantStream(participantId: string, stream: MediaStream | null) {
+      const participant = this.participants[participantId]
+      if (!participant) return
+      this.participants[participantId] = {
+        ...participant,
+        stream,
+      }
+    },
+    setParticipantMuted(participantId: string, muted: boolean) {
+      const participant = this.participants[participantId]
+      if (!participant) return
+      this.participants[participantId] = {
+        ...participant,
+        muted,
+      }
+    },
+    reset() {
+      Object.values(this.participants).forEach((participant) => {
+        participant.stream?.getTracks().forEach((track) => track.stop())
+      })
+      this.participants = {}
+      this.localStream?.getTracks().forEach((track) => track.stop())
+      this.localStream = null
+      this.localMuted = false
+      this.identity = { roomId: '', username: '' }
+      this.joined = false
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add a VoiceRoom component that joins signalling, manages transports, and renders local/remote participants
- introduce a Pinia voice store to track identity, local media, and participant mute state
- provide socket and WebRTC helper composables to manage signalling requests and basic transport lifecycle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc5e9a5e1c8324bc0892d47d8a08fa