### PR TITLE
Add controls to hide dashboard pomodoro timer

### DIFF
--- a/pages/components/dashboard/pomodoroTimer.vue
+++ b/pages/components/dashboard/pomodoroTimer.vue
@@ -1,19 +1,28 @@
 <template>
   <div class="bg-white rounded-xl shadow p-6 flex flex-col h-full">
     <div class="flex items-start justify-between gap-2">
-      <div>
+      <div class="min-w-0 flex-1">
         <h2 class="text-xl font-semibold text-gray-800">Pomodoro Zamanlayıcısı</h2>
         <p class="text-sm text-gray-500">
           Odak sürenizi yönetmek için Pomodoro yöntemi kullanın.
         </p>
       </div>
-      <span
-        class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-sm"
-        :class="currentPhase === 'focus' ? 'bg-red-100 text-red-600' : 'bg-emerald-100 text-emerald-600'"
-      >
-        <span class="h-2 w-2 rounded-full" :class="currentPhase === 'focus' ? 'bg-red-500' : 'bg-emerald-500'"></span>
-        {{ phaseLabel }}
-      </span>
+      <div class="flex items-center gap-2">
+        <span
+          class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-sm"
+          :class="currentPhase === 'focus' ? 'bg-red-100 text-red-600' : 'bg-emerald-100 text-emerald-600'"
+        >
+          <span class="h-2 w-2 rounded-full" :class="currentPhase === 'focus' ? 'bg-red-500' : 'bg-emerald-500'"></span>
+          {{ phaseLabel }}
+        </span>
+        <button
+          type="button"
+          class="rounded-md border border-gray-200 px-2.5 py-1 text-xs font-medium text-gray-600 transition hover:bg-gray-100 hover:text-gray-800"
+          @click="handleHidePanel"
+        >
+          Gizle
+        </button>
+      </div>
     </div>
 
     <div class="mt-4 text-sm text-gray-600" v-if="linkedProjectName">
@@ -114,6 +123,8 @@ import { storeToRefs } from 'pinia'
 import { usePomodoroStore } from '@/stores/pomodoroStore'
 import { useProjectStore } from '@/stores/projectStore'
 
+const emit = defineEmits<{ (e: 'hide'): void }>()
+
 const pomodoroStore = usePomodoroStore()
 const projectStore = useProjectStore()
 
@@ -173,6 +184,11 @@ const handleReset = () => {
 
 const handlePhaseToggle = () => {
   pomodoroStore.togglePhase(true)
+}
+
+const handleHidePanel = () => {
+  pomodoroStore.pauseTimer()
+  emit('hide')
 }
 
 const formatSessionDate = (dateIso: string) => {


### PR DESCRIPTION
## Summary
- add a visibility toggle for the dashboard pomodoro timer and persist it in localStorage across sessions
- update the pomodoro timer component with a hide trigger and pause the store timer when it is dismissed
- provide UI affordances in mobile and desktop layouts to restore the pomodoro panel when hidden

## Testing
- npm run lint *(fails: Missing script "lint")*
- npm run dev -- --hostname 0.0.0.0 --port 3000 *(passes, used for visual verification)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5fa7896883249dc12ef3b3ebcb18