### PR TITLE
feat: track project focus totals in pomodoro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ pnpm-lock.yaml
 .output/
 dist/
 .cache/
+.tmp-tests/
 
 # Static build artifacts
 *.log

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",
-    "start": "node .output/server/index.mjs"
+    "start": "node .output/server/index.mjs",
+    "test": "rm -rf .tmp-tests && tsc -p tests/tsconfig.json && node -e \"require('fs').writeFileSync('.tmp-tests/package.json', '{\\\"type\\\":\\\"commonjs\\\"}')\" && node --test .tmp-tests/tests/pomodoroStore.spec.js"
   },
   "dependencies": {
     "@ckeditor/ckeditor5-build-classic": "^44.3.0",

--- a/pages/components/dashboard/pomodoroTimer.vue
+++ b/pages/components/dashboard/pomodoroTimer.vue
@@ -104,6 +104,26 @@
           </li>
         </ul>
       </div>
+      <div class="mt-6">
+        <h3 class="text-sm font-semibold text-gray-700 mb-2">Projelere Göre Toplam Odak Süresi</h3>
+        <ul v-if="projectTotalsList.length" class="space-y-2 max-h-40 overflow-y-auto pr-1">
+          <li
+            v-for="projectTotal in projectTotalsList"
+            :key="projectTotal.projectId"
+            class="flex items-center justify-between text-sm text-gray-600"
+          >
+            <span class="font-medium text-gray-800">
+              {{ projectTotal.projectName ?? `Proje #${projectTotal.projectId}` }}
+            </span>
+            <span class="text-xs bg-blue-50 text-blue-600 px-2 py-1 rounded-full">
+              {{ projectTotal.totalFocusMinutes }} dk
+            </span>
+          </li>
+        </ul>
+        <p v-else class="text-sm text-gray-400 text-center py-2">
+          Henüz projelere bağlı odak süresi bulunmuyor.
+        </p>
+      </div>
     </div>
   </div>
 </template>
@@ -126,7 +146,8 @@ const {
   completedSessions,
   sessionHistory,
   linkedProjectName,
-  linkedProjectId
+  linkedProjectId,
+  projectTotals
 } = storeToRefs(pomodoroStore)
 
 const workDurationInput = ref(workDuration.value)
@@ -158,6 +179,9 @@ const progress = computed(() => {
 })
 
 const recentSessions = computed(() => sessionHistory.value.slice(0, 5))
+const projectTotalsList = computed(() =>
+  Object.values(projectTotals.value).sort((a, b) => b.totalFocusMinutes - a.totalFocusMinutes)
+)
 
 const handleStartPause = () => {
   if (isActive.value) {

--- a/tests/globals.d.ts
+++ b/tests/globals.d.ts
@@ -1,0 +1,17 @@
+declare module 'node:test' {
+  export function describe(name: string, fn: () => void): void
+  export function it(name: string, fn: () => void): void
+  export function beforeEach(fn: () => void): void
+}
+
+declare module 'node:assert/strict' {
+  const assert: {
+    deepStrictEqual(actual: unknown, expected: unknown): void
+    strictEqual(actual: unknown, expected: unknown): void
+  }
+  export default assert
+}
+
+declare const process: {
+  client?: boolean
+}

--- a/tests/pomodoroStore.spec.ts
+++ b/tests/pomodoroStore.spec.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import { beforeEach, describe, it } from 'node:test'
+import { createPinia, setActivePinia } from 'pinia'
+
+import { usePomodoroStore } from '../stores/pomodoroStore'
+
+describe('pomodoro store project totals', () => {
+  const storage = new Map<string, string>()
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    ;(process as any).client = true
+    storage.clear()
+    const localStorage = {
+      getItem: (key: string) => (storage.has(key) ? storage.get(key)! : null),
+      setItem: (key: string, value: string) => {
+        storage.set(key, value)
+      },
+      removeItem: (key: string) => {
+        storage.delete(key)
+      },
+      clear: () => {
+        storage.clear()
+      }
+    }
+    globalThis.window = { localStorage } as any
+  })
+
+  it('creates and updates totals when project link changes', () => {
+    const store = usePomodoroStore()
+    store.linkProject(1, 'Öncelikli Proje')
+
+    assert.deepStrictEqual(store.projectTotals['1'], {
+      projectId: 1,
+      projectName: 'Öncelikli Proje',
+      totalFocusMinutes: 0
+    })
+
+    store.linkProject(1, 'Güncel Proje Adı')
+
+    assert.deepStrictEqual(store.projectTotals['1'], {
+      projectId: 1,
+      projectName: 'Güncel Proje Adı',
+      totalFocusMinutes: 0
+    })
+  })
+
+  it('accumulates focus minutes per project when sessions are recorded', () => {
+    const store = usePomodoroStore()
+    store.linkProject(42, 'Analiz Projesi')
+
+    store.recordSession()
+    store.recordSession()
+
+    assert.deepStrictEqual(store.projectTotals['42'], {
+      projectId: 42,
+      projectName: 'Analiz Projesi',
+      totalFocusMinutes: store.workDuration * 2
+    })
+  })
+
+  it('does not change project totals when project link is cleared', () => {
+    const store = usePomodoroStore()
+    store.linkProject(5, 'Temizlenecek Proje')
+    store.recordSession()
+
+    store.linkProject(null, null)
+    store.recordSession()
+
+    assert.strictEqual(store.projectTotals['5'].totalFocusMinutes, store.workDuration)
+    assert.strictEqual(store.projectTotals['5'].projectName, 'Temizlenecek Proje')
+  })
+})

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "outDir": "../.tmp-tests",
+    "rootDir": "..",
+    "resolveJsonModule": true
+  },
+  "include": [
+    "../stores/pomodoroStore.ts",
+    "./pomodoroStore.spec.ts",
+    "./globals.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- persist per-project Pomodoro focus totals in the store so they survive reloads
- show aggregated focus minutes per project in the dashboard Pomodoro timer
- add node-based scenario tests covering linking, recording, and clearing project associations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc5fac5b548324a0cbfe4093549998